### PR TITLE
git ignore app/app-release.apk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ local.properties
 .Trashes
 ehthumbs.db
 Thumbs.db
+app/app-release.apk


### PR DESCRIPTION
handy for those going to build signed "release" apps