### PR TITLE
enable relative URLs in most places

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.util.Log;
-
 import com.jasonette.seed.Helper.JasonHelper;
 import org.json.JSONObject;
 import java.io.IOException;

--- a/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.util.Log;
+
 import com.jasonette.seed.Helper.JasonHelper;
 import org.json.JSONObject;
 import java.io.IOException;
@@ -22,7 +23,7 @@ public class JasonNetworkAction {
         try{
             final JSONObject options = action.getJSONObject("options");
             if(options.has("url")){
-                String url = options.getString("url");
+                String url = JasonHelper.url(options.getString("url"), context);
 
                 // method
                 String method = "GET";

--- a/app/src/main/java/com/jasonette/seed/Component/JasonImageComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonImageComponent.java
@@ -80,7 +80,8 @@ public class JasonImageComponent {
                     }
                 }
 
-                url = new GlideUrl(component.getString("url"), builder.build());
+                String url_string = JasonHelper.url(component.getString("url"), context);
+                url = new GlideUrl(url_string, builder.build());
 
                 if (style.has("corner_radius")) {
                     corner_radius = JasonHelper.pixels(context, style.getString("corner_radius"), "horizontal");

--- a/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
@@ -19,6 +19,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.regex.Matcher;
@@ -228,5 +230,14 @@ public class JasonHelper {
         reader.close();
         inputStream.close();
         return stringBuilder.toString();
+    }
+    public static String url(String url, Context context) throws MalformedURLException {
+        try {
+            // Validate the URL
+            return new URL(url).toString();
+        } catch(MalformedURLException e) {
+            // The URL might be relative, try to build it based on the current URL
+            return new URL(new URL(((JasonViewActivity)context).url), url).toString();
+        }
     }
 }


### PR DESCRIPTION
I thought being able to use relative JSON urls would make it easier to share jasonette applications. For one example, I modified the jasonpedia demo app to use all relative URLs. To try:

1. `git clone --branch relative-urls git@github.com:brad/Jasonpedia.git`
2. `cd Jasonpedia`
3. `python -m http.server 8000` (or with Python 2: `python -m SimpleHTTPServer 8000`)
4. Set the URL in `strings.xml` to `http://x.x.x.x:8000/demo.json` where `x.x.x.x` is an IP address on the local network for your computer that is also accessible to the mobile device
5. Install the app.

It should be completely functional (except for the missing Android features) and you can edit the json files locally and see the changes. The URLs are relative to the domain of the URL in `strings.xml`. You can just use the filename (`other_json.json`) to refer to a file at the same level as the current json, or `./` can also refer to files at the same level. You can also use `../` to refer to files one level up, or start the path with `/` to refer to the root of the domain.