### PR TITLE
Mention the Android settings file, not iOS

### DIFF
--- a/app/src/main/assets/file/jasonpedia.json
+++ b/app/src/main/assets/file/jasonpedia.json
@@ -43,7 +43,7 @@
                 },
                 {
                   "type": "label",
-                  "text": "This is a demo app. You can make your own app by changing the url inside settings.plist",
+                  "text": "This is a demo app. You can make your own app by changing the url inside strings.xml",
                   "style": {
                     "align": "center",
                     "font": "Courier",


### PR DESCRIPTION
Just changing `settings.plist` to `strings.xml`. Apparently the Github editor adds newlines to the ends of files