### PR TITLE
enable usage of javascript console methods

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
@@ -57,6 +57,12 @@ public class JasonParser {
                     try {
                         // thread handling - acquire handle
                         juice.getLocker().acquire();
+                        Console console = new Console();
+                        V8Object v8Console = new V8Object(juice);
+                        juice.add("console", v8Console);
+                        v8Console.registerJavaMethod(console, "log", "log", new Class<?>[] { String.class });
+                        v8Console.registerJavaMethod(console, "error", "error", new Class<?>[] { String.class });
+                        v8Console.registerJavaMethod(console, "trace", "trace", new Class<?>[] {});
 
                         V8Object parser = juice.getObject("parser");
 
@@ -79,6 +85,7 @@ public class JasonParser {
                             parameters.release();
                         }
                         parser.release();
+                        v8Console.release();
 
 
                         res = new JSONObject(val);
@@ -99,4 +106,17 @@ public class JasonParser {
 }
 
 
-
+/**
+ * Override for console to print javascript debug output in the Android Studio console
+ */
+class Console {
+    public void log(final String message) {
+        Log.d("console.log", message);
+    }
+    public void error(final String message) {
+        Log.e("console.error", message);
+    }
+    public void trace() {
+        Log.e("console.trace", "Unable to reproduce JS stacktrace");
+    }
+}


### PR DESCRIPTION
@gliechtenstein This lets you do simple JavaScript debugging using `console`, the output will appear in the Android console. This works for debugging both the code in `parser` as well as any JS used in template tags.