### PR TITLE
Fixes OAuth action doubling up on some query params

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Action/JasonOauthAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonOauthAction.java
@@ -197,7 +197,7 @@ public class JasonOauthAction {
                         Iterator paramKeys = authorize_options_data.keys();
                         while(paramKeys.hasNext()) {
                             String key = (String)paramKeys.next();
-                            if(key != "redirect_uri" || key != "response_type" || key != "scope" || key != "state") {
+                            if(key != "redirect_uri" && key != "response_type" && key != "scope" && key != "state") {
                                 String value = authorize_options_data.getString(key);
                                 additionalParams.put(key, value);
                             }
@@ -314,7 +314,7 @@ public class JasonOauthAction {
                                     Iterator paramKeys = authorize_options_data.keys();
                                     while(paramKeys.hasNext()) {
                                         String key = (String)paramKeys.next();
-                                        if(key != "redirect_uri" || key != "response_type" || key != "scope" || key != "state") {
+                                        if(key != "redirect_uri" && key != "response_type" && key != "scope" && key != "state") {
                                             String value = authorize_options_data.getString(key);
                                             additionalParams.put(key, value);
                                         }


### PR DESCRIPTION
Hey there, just a tiny bug I ran into with the OAuth stuff.

Because it's using OR instead of AND operator, these params ('redirect_uri', 'scope' etc) that have already been added to the query get appended on the end again. In most cases, this doesn't really matter but Google squawks if you pass through the same param multiple times