### PR TITLE
Timber stetho

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,10 +25,9 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-
     debugCompile 'com.facebook.stetho:stetho:1.5.0'
     debugCompile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
-
+    debugCompile 'com.facebook.stetho:stetho-timber:1.5.0'
     compile 'com.android.support:appcompat-v7:25.0.1'
     compile 'com.google.android.gms:play-services-maps:10.0.1'
     compile 'com.squareup.okhttp3:okhttp:3.4.2'
@@ -46,4 +45,5 @@ dependencies {
     compile 'com.github.adrielcafe:AndroidAudioRecorder:0.2.0'
     compile 'com.github.adrielcafe:AndroidAudioConverter:0.0.8'
     compile 'com.github.florent37:singledateandtimepicker:1.0.8'
+    compile 'com.jakewharton.timber:timber:4.5.1'
 }

--- a/app/src/debug/java/com/jasonette/seed/Launcher/DebugLauncher.java
+++ b/app/src/debug/java/com/jasonette/seed/Launcher/DebugLauncher.java
@@ -1,14 +1,20 @@
 package com.jasonette.seed.Launcher;
 
+import android.content.res.Resources;
 import android.util.Log;
 
 import com.facebook.stetho.Stetho;
 import com.facebook.stetho.okhttp3.StethoInterceptor;
+import com.facebook.stetho.timber.StethoTree;
+import com.jasonette.seed.R;
 
 import okhttp3.OkHttpClient;
+import timber.log.Timber;
 
 /**
- * Provides debug-build specific Application
+ * Provides debug-build specific Application.
+ * 
+ * To disable Stetho console logging change the setting in src/debug/res/values/bools.xml
  */
 public class DebugLauncher extends Launcher {
 
@@ -18,8 +24,17 @@ public class DebugLauncher extends Launcher {
     public void onCreate() {
         super.onCreate();
 
-        Log.d(LOGTAG, "Initialised Stetho debugging");
         Stetho.initializeWithDefaults(this);
+        Resources res = getResources();
+        boolean enableStethoConsole = res.getBoolean(R.bool.enableStethoConsole);
+
+        if (enableStethoConsole) {
+            Timber.plant(new StethoTree());
+            Log.i(LOGTAG, "Using Stetho console logging");
+        } else  {
+            Timber.plant(new Timber.DebugTree());
+        }
+        Timber.i("Initialised Stetho debugging"+getEnv());
     }
 
     @Override

--- a/app/src/debug/res/values/bools.xml
+++ b/app/src/debug/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enableStethoConsole">true</bool>
+</resources>

--- a/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
@@ -1,7 +1,6 @@
 package com.jasonette.seed.Core;
 
 import android.content.Context;
-import android.util.Log;
 
 import com.eclipsesource.v8.V8;
 import com.eclipsesource.v8.V8Array;
@@ -9,6 +8,8 @@ import com.eclipsesource.v8.V8Object;
 import com.jasonette.seed.Helper.JasonHelper;
 
 import org.json.JSONObject;
+
+import timber.log.Timber;
 
 public class JasonParser {
     static JSONObject res;
@@ -41,7 +42,7 @@ public class JasonParser {
                 instance.juice.executeVoidScript(js);
                 instance.juice.getLocker().release();
             } catch (Exception e){
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
             }
         }
         return instance;
@@ -92,7 +93,7 @@ public class JasonParser {
                         listener.onFinished(res);
 
                     } catch (Exception e){
-                        Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
                     }
 
                     // thread handling - release handle
@@ -100,7 +101,7 @@ public class JasonParser {
                }
             }).start();
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
         }
     }
 }
@@ -111,12 +112,12 @@ public class JasonParser {
  */
 class Console {
     public void log(final String message) {
-        Log.d("console.log", message);
+        Timber.d(message);
     }
     public void error(final String message) {
-        Log.e("console.error", message);
+        Timber.e(message);
     }
     public void trace() {
-        Log.e("console.trace", "Unable to reproduce JS stacktrace");
+        Timber.e("Unable to reproduce JS stacktrace");
     }
 }


### PR DESCRIPTION
This adds ability to use the Stetho console for logging output from Jasonette. 
Currently only console.* output from JS with expression templates is using this. 
The setting is controlled via a bool resource and is defaulted to on.
