### PR TITLE
Fix #124: Center the header's title

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Component/JasonLabelComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonLabelComponent.java
@@ -27,40 +27,8 @@ public class JasonLabelComponent {
                     int color = JasonHelper.parse_color(style.getString("color"));
                     ((TextView)view).setTextColor(color);
                 }
-                if (style.has("font:android")){
-                    String f = style.getString("font:android");
-                    if(f.equalsIgnoreCase("bold")){
-                        ((TextView) view).setTypeface(Typeface.DEFAULT_BOLD);
-                    } else if(f.equalsIgnoreCase("sans")){
-                        ((TextView) view).setTypeface(Typeface.SANS_SERIF);
-                    } else if(f.equalsIgnoreCase("serif")){
-                        ((TextView) view).setTypeface(Typeface.SERIF);
-                    } else if(f.equalsIgnoreCase("monospace")){
-                        ((TextView) view).setTypeface(Typeface.MONOSPACE);
-                    } else if(f.equalsIgnoreCase("default")){
-                        ((TextView) view).setTypeface(Typeface.DEFAULT);
-                    } else {
-                        try {
-                            Typeface font_type = Typeface.createFromAsset(context.getAssets(), "fonts/" + style.getString("font:android") + ".ttf");
-                            ((TextView) view).setTypeface(font_type);
-                        } catch (Exception e) {
-                        }
-                    }
-                } else if (style.has("font")){
-                   if(style.getString("font").toLowerCase().contains("bold")) {
-                       if (style.getString("font").toLowerCase().contains("italic")) {
-                           ((TextView) view).setTypeface(Typeface.DEFAULT_BOLD, Typeface.ITALIC);
-                       } else {
-                           ((TextView) view).setTypeface(Typeface.DEFAULT_BOLD);
-                       }
-                   } else {
-                       if (style.getString("font").toLowerCase().contains("italic")) {
-                           ((TextView) view).setTypeface(Typeface.DEFAULT, Typeface.ITALIC);
-                       } else {
-                           ((TextView) view).setTypeface(Typeface.DEFAULT);
-                       }
-                   }
-                }
+
+                JasonHelper.setTextViewFont(((TextView)view), style, context);
 
                 int g = 0;
                 if (style.has("align")) {

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2348,7 +2348,15 @@ public class JasonViewActivity extends AppCompatActivity {
 
     void setup_title(JSONObject header) {
         try {
+            // Default title values
             toolbar.setTitle("");
+            toolbar.setTitleSize(20);
+
+            // Global font
+            if(header.has("style")) {
+                toolbar.setTitleFont(header.getJSONObject("style"));
+            }
+
             if (header.has("title")) {
                 Object title = header.get("title");
                 if (title instanceof String) {
@@ -2406,16 +2414,12 @@ public class JasonViewActivity extends AppCompatActivity {
                             if (align.equals("center")) {
                                 toolbar.setAlignment(Gravity.CENTER);
                             }
-                            else if (align.equals("right")) {
-                                toolbar.setAlignment(Gravity.RIGHT);
-                            }
                             else {
                                 toolbar.setAlignment(Gravity.LEFT);
                             }
 
                             // Offsets
                             int leftOffset = 0;
-                            int rightOffset = 0;
                             int topOffset = 0;
 
                             try {
@@ -2423,21 +2427,19 @@ public class JasonViewActivity extends AppCompatActivity {
                             } catch (JSONException e) {}
 
                             try {
-                                rightOffset = ((JSONObject) style).getInt("right");
-                            } catch (JSONException e) {}
-
-                            try {
                                 topOffset = ((JSONObject) style).getInt("top");
                             } catch (JSONException e) {}
 
                             toolbar.setLeftOffset(leftOffset);
-                            toolbar.setRightOffset(rightOffset);
                             toolbar.setTopOffset(topOffset);
 
                             // Size
                             try {
                                 toolbar.setTitleSize(Float.parseFloat(((JSONObject) style).getString("size")));
                             } catch (JSONException e) {}
+
+                            // Font
+                            toolbar.setTitleFont(style);
                         }
 
                         toolbar.setTitle(text);
@@ -2462,17 +2464,7 @@ public class JasonViewActivity extends AppCompatActivity {
         } catch (Exception e) {
             Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
         }
-        try {
-            toolbar.setTitleSize(20);
-            if(header.has("style")) {
-                String f = header.getJSONObject("style").getString("font:android");
-                Typeface font = JasonHelper.get_font(f, this);
-                toolbar.setTitleTypeface(font);
-            }
 
-        } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
-        }
     }
 
     /******************

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -53,7 +53,7 @@ import com.jasonette.seed.Component.JasonImageComponent;
 import com.jasonette.seed.Helper.JasonHelper;
 import com.jasonette.seed.Launcher.Launcher;
 import com.jasonette.seed.Lib.BackgroundCameraManager;
-import com.jasonette.seed.Lib.CenteredToolbar;
+import com.jasonette.seed.Lib.JasonToolbar;
 import com.jasonette.seed.Lib.MaterialBadgeTextView;
 import com.jasonette.seed.R;
 import com.jasonette.seed.Section.ItemAdapter;
@@ -77,7 +77,7 @@ import java.util.concurrent.Executors;
 import static com.bumptech.glide.Glide.with;
 
 public class JasonViewActivity extends AppCompatActivity {
-    private CenteredToolbar toolbar;
+    private JasonToolbar toolbar;
     private RecyclerView listView;
     public String url;
     public JasonModel model;
@@ -157,7 +157,7 @@ public class JasonViewActivity extends AppCompatActivity {
 
         // 3. Create body.header
         if(toolbar == null) {
-            toolbar = new CenteredToolbar(this);
+            toolbar = new JasonToolbar(this);
             toolbar.setTitle("");
         }
         setSupportActionBar(toolbar);
@@ -2394,7 +2394,51 @@ public class JasonViewActivity extends AppCompatActivity {
                                 .into((ImageView) logoView);
                     } else if(type.equalsIgnoreCase("label")){
                         String text = ((JSONObject) title).getString("text");
+                        JSONObject style = ((JSONObject) title).getJSONObject("style");
+
+                        if (style instanceof JSONObject) {
+                            // Title alignment
+                            String align = "left";
+                            try {
+                                align = ((JSONObject) style).getString("align");
+                            } catch (JSONException e) {}
+
+                            if (align.equals("center")) {
+                                toolbar.setAlignment(Gravity.CENTER);
+                            }
+                            else if (align.equals("right")) {
+                                toolbar.setAlignment(Gravity.RIGHT);
+                            }
+                            else {
+                                toolbar.setAlignment(Gravity.LEFT);
+                            }
+
+                            // Offsets
+                            int leftOffset = 0;
+                            int rightOffset = 0;
+                            int topOffset = 0;
+
+                            try {
+                                leftOffset = ((JSONObject) style).getInt("left");
+                            } catch (JSONException e) {}
+
+                            try {
+                                rightOffset = ((JSONObject) style).getInt("right");
+                            } catch (JSONException e) {}
+
+                            try {
+                                topOffset = ((JSONObject) style).getInt("top");
+                            } catch (JSONException e) {}
+
+                            toolbar.setLeftOffset(leftOffset);
+                            toolbar.setRightOffset(rightOffset);
+                            toolbar.setTopOffset(topOffset);
+                        }
+
                         toolbar.setTitle(text);
+
+
+
                         if(logoView != null){
                             toolbar.removeView(logoView);
                             logoView = null;

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2378,16 +2378,20 @@ public class JasonViewActivity extends AppCompatActivity {
 
                     if (style != null) {
                         // title alignment
-                        String align = "left";
+                        String align;
                         try {
                             align = style.getString("align");
-                        } catch (JSONException e) {
-                            toolbar.setAlignment(-1);
-                        }
 
-                        if (align.equals("center")) {
-                            toolbar.setAlignment(Gravity.CENTER);
-                        } else {
+                            if (align.equals("center")) {
+                                toolbar.setAlignment(Gravity.CENTER);
+                            }
+                            else if (align.equals("left")) {
+                                toolbar.setAlignment(Gravity.LEFT);
+                            }
+                            else {
+                                toolbar.setAlignment(-1);
+                            }
+                        } catch (JSONException e) {
                             toolbar.setAlignment(-1);
                         }
 

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2433,11 +2433,14 @@ public class JasonViewActivity extends AppCompatActivity {
                             toolbar.setLeftOffset(leftOffset);
                             toolbar.setRightOffset(rightOffset);
                             toolbar.setTopOffset(topOffset);
+
+                            // Size
+                            try {
+                                toolbar.setTitleSize(Float.parseFloat(((JSONObject) style).getString("size")));
+                            } catch (JSONException e) {}
                         }
 
                         toolbar.setTitle(text);
-
-
 
                         if(logoView != null){
                             toolbar.removeView(logoView);

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2368,15 +2368,55 @@ public class JasonViewActivity extends AppCompatActivity {
                         logoView = null;
                     }
                 } else if (title instanceof JSONObject) {
-                    String type = ((JSONObject) title).getString("type");
+                    JSONObject t = ((JSONObject) title);
+                    String type = t.getString("type");
+                    JSONObject style = null;
+
+                    if (t.has("style")) {
+                        style = t.getJSONObject("style");
+                    }
+
+                    if (style != null) {
+                        // title alignment
+                        String align = "left";
+                        try {
+                            align = style.getString("align");
+                        } catch (JSONException e) {
+                            toolbar.setAlignment(-1);
+                        }
+
+                        if (align.equals("center")) {
+                            toolbar.setAlignment(Gravity.CENTER);
+                        } else {
+                            toolbar.setAlignment(-1);
+                        }
+
+                        // offsets
+                        int leftOffset = 0;
+                        int topOffset = 0;
+
+                        try {
+                            leftOffset = style.getInt("left");
+                        } catch (JSONException e) {
+                        }
+
+                        try {
+                            topOffset = style.getInt("top");
+                        } catch (JSONException e) {
+                        }
+
+                        toolbar.setLeftOffset(leftOffset);
+                        toolbar.setTopOffset(topOffset);
+                    }
+
+                    // image options
                     if (type.equalsIgnoreCase("image")) {
-                        String url = ((JSONObject) title).getString("url");
+                        String url = t.getString("url");
                         JSONObject c = new JSONObject();
                         c.put("url", url);
                         int height = header_height;
                         int width = Toolbar.LayoutParams.WRAP_CONTENT;
-                        if (((JSONObject) title).has("style")) {
-                            JSONObject style = ((JSONObject) title).getJSONObject("style");
+                        if (style != null) {
                             if (style.has("height")) {
                                 try {
                                     height = (int) JasonHelper.pixels(this, style.getString("height"), "vertical");
@@ -2392,55 +2432,22 @@ public class JasonViewActivity extends AppCompatActivity {
                                 }
                             }
                         }
-                        if (logoView == null) {
-                            logoView = new ImageView(JasonViewActivity.this);
-                            toolbar.addView(logoView);
-                        }
-                        Toolbar.LayoutParams params = new Toolbar.LayoutParams(width, height);
-                        params.gravity = Gravity.CENTER_HORIZONTAL;
-                        logoView.setLayoutParams(params);
-                        Glide.with(this)
-                                .load(JasonImageComponent.resolve_url(c, JasonViewActivity.this))
-                                .into((ImageView) logoView);
-                    } else if(type.equalsIgnoreCase("label")){
+
+                        toolbar.setImageHeight(height);
+                        toolbar.setImageWidth(width);
+                        toolbar.setImage(c);
+                    }
+                    // label options
+                    else if(type.equalsIgnoreCase("label")){
                         String text = ((JSONObject) title).getString("text");
-                        JSONObject style = ((JSONObject) title).getJSONObject("style");
 
-                        if (style instanceof JSONObject) {
-                            // Title alignment
-                            String align = "left";
+                        if (style != null) {
+                            // size
                             try {
-                                align = ((JSONObject) style).getString("align");
+                                toolbar.setTitleSize(Float.parseFloat(style.getString("size")));
                             } catch (JSONException e) {}
 
-                            if (align.equals("center")) {
-                                toolbar.setAlignment(Gravity.CENTER);
-                            }
-                            else {
-                                toolbar.setAlignment(Gravity.LEFT);
-                            }
-
-                            // Offsets
-                            int leftOffset = 0;
-                            int topOffset = 0;
-
-                            try {
-                                leftOffset = ((JSONObject) style).getInt("left");
-                            } catch (JSONException e) {}
-
-                            try {
-                                topOffset = ((JSONObject) style).getInt("top");
-                            } catch (JSONException e) {}
-
-                            toolbar.setLeftOffset(leftOffset);
-                            toolbar.setTopOffset(topOffset);
-
-                            // Size
-                            try {
-                                toolbar.setTitleSize(Float.parseFloat(((JSONObject) style).getString("size")));
-                            } catch (JSONException e) {}
-
-                            // Font
+                            // font
                             toolbar.setTitleFont(style);
                         }
 

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -30,7 +30,6 @@ import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
-import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 import android.webkit.CookieManager;
@@ -42,20 +41,19 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
-import android.widget.TextView;
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigation;
 import com.aurelhubert.ahbottomnavigation.AHBottomNavigationItem;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.bumptech.glide.request.animation.GlideAnimation;
-import com.bumptech.glide.request.target.GlideDrawableImageViewTarget;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.jasonette.seed.Component.JasonComponentFactory;
 import com.jasonette.seed.Component.JasonImageComponent;
 import com.jasonette.seed.Helper.JasonHelper;
 import com.jasonette.seed.Launcher.Launcher;
 import com.jasonette.seed.Lib.BackgroundCameraManager;
+import com.jasonette.seed.Lib.CenteredToolbar;
 import com.jasonette.seed.Lib.MaterialBadgeTextView;
 import com.jasonette.seed.R;
 import com.jasonette.seed.Section.ItemAdapter;
@@ -79,7 +77,7 @@ import java.util.concurrent.Executors;
 import static com.bumptech.glide.Glide.with;
 
 public class JasonViewActivity extends AppCompatActivity {
-    private Toolbar toolbar;
+    private CenteredToolbar toolbar;
     private RecyclerView listView;
     public String url;
     public JasonModel model;
@@ -159,7 +157,7 @@ public class JasonViewActivity extends AppCompatActivity {
 
         // 3. Create body.header
         if(toolbar == null) {
-            toolbar = new Toolbar(this);
+            toolbar = new CenteredToolbar(this);
             toolbar.setTitle("");
         }
         setSupportActionBar(toolbar);
@@ -2418,23 +2416,11 @@ public class JasonViewActivity extends AppCompatActivity {
             Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
         }
         try {
-            for (int i = 0; i < toolbar.getChildCount(); ++i) {
-                View child = toolbar.getChildAt(i);
-                if (child instanceof TextView) {
-                    ((TextView) child).setTextSize(20);
-                    break;
-                }
-            }
+            toolbar.setTitleSize(20);
             if(header.has("style")) {
                 String f = header.getJSONObject("style").getString("font:android");
                 Typeface font = JasonHelper.get_font(f, this);
-                for (int i = 0; i < toolbar.getChildCount(); ++i) {
-                    View child = toolbar.getChildAt(i);
-                    if (child instanceof TextView) {
-                        ((TextView) child).setTypeface(font);
-                        break;
-                    }
-                }
+                toolbar.setTitleTypeface(font);
             }
 
         } catch (Exception e) {

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2144,6 +2144,9 @@ public class JasonViewActivity extends AppCompatActivity {
         try {
             menu = toolbar.getMenu();
             if (model.rendered != null) {
+                if(!model.rendered.has("header")){
+                    setup_title(new JSONObject());
+                }
                 JSONObject header = model.rendered.getJSONObject("header");
 
                 header_height = toolbar.getHeight();
@@ -2361,6 +2364,10 @@ public class JasonViewActivity extends AppCompatActivity {
 
             if (header.has("title")) {
                 Object title = header.get("title");
+
+                // set align:center by default
+                toolbar.setAlignment(Gravity.CENTER);
+
                 if (title instanceof String) {
                     toolbar.setTitle(header.getString("title"));
                     if(logoView != null){
@@ -2397,12 +2404,12 @@ public class JasonViewActivity extends AppCompatActivity {
                         int topOffset = 0;
 
                         try {
-                            leftOffset = style.getInt("left");
+                            leftOffset = (int)JasonHelper.pixels(JasonViewActivity.this, style.getString("left"), "horizontal");
                         } catch (JSONException e) {
                         }
 
                         try {
-                            topOffset = style.getInt("top");
+                            topOffset = (int)JasonHelper.pixels(JasonViewActivity.this, style.getString("top"), "vertical");
                         } catch (JSONException e) {
                         }
 

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2379,6 +2379,7 @@ public class JasonViewActivity extends AppCompatActivity {
                     if (style != null) {
                         // title alignment
                         String align;
+                        toolbar.setAlignment(-1);
                         try {
                             align = style.getString("align");
 
@@ -2388,11 +2389,7 @@ public class JasonViewActivity extends AppCompatActivity {
                             else if (align.equals("left")) {
                                 toolbar.setAlignment(Gravity.LEFT);
                             }
-                            else {
-                                toolbar.setAlignment(-1);
-                            }
                         } catch (JSONException e) {
-                            toolbar.setAlignment(-1);
                         }
 
                         // offsets

--- a/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
@@ -10,11 +10,13 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.WindowManager;
+import android.widget.TextView;
 
 import com.jasonette.seed.Core.JasonViewActivity;
 import com.jasonette.seed.Launcher.Launcher;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -379,4 +381,42 @@ public class JasonHelper {
         }
     }
 
+    public static void setTextViewFont(TextView view, JSONObject style, Context context) {
+        try {
+            if (style.has("font:android")) {
+                String f = style.getString("font:android");
+                if (f.equalsIgnoreCase("bold")) {
+                    view.setTypeface(Typeface.DEFAULT_BOLD);
+                } else if (f.equalsIgnoreCase("sans")) {
+                    view.setTypeface(Typeface.SANS_SERIF);
+                } else if (f.equalsIgnoreCase("serif")) {
+                    view.setTypeface(Typeface.SERIF);
+                } else if (f.equalsIgnoreCase("monospace")) {
+                    view.setTypeface(Typeface.MONOSPACE);
+                } else if (f.equalsIgnoreCase("default")) {
+                    view.setTypeface(Typeface.DEFAULT);
+                } else {
+                    try {
+                        Typeface font_type = Typeface.createFromAsset(context.getAssets(), "fonts/" + style.getString("font:android") + ".ttf");
+                        view.setTypeface(font_type);
+                    } catch (Exception e) {
+                    }
+                }
+            } else if (style.has("font")) {
+                if (style.getString("font").toLowerCase().contains("bold")) {
+                    if (style.getString("font").toLowerCase().contains("italic")) {
+                        view.setTypeface(Typeface.DEFAULT_BOLD, Typeface.ITALIC);
+                    } else {
+                        view.setTypeface(Typeface.DEFAULT_BOLD);
+                    }
+                } else {
+                    if (style.getString("font").toLowerCase().contains("italic")) {
+                        view.setTypeface(Typeface.DEFAULT, Typeface.ITALIC);
+                    } else {
+                        view.setTypeface(Typeface.DEFAULT);
+                    }
+                }
+            }
+        } catch (JSONException e) {}
+    }
 }

--- a/app/src/main/java/com/jasonette/seed/Lib/CenteredToolbar.java
+++ b/app/src/main/java/com/jasonette/seed/Lib/CenteredToolbar.java
@@ -1,0 +1,69 @@
+package com.jasonette.seed.Lib;
+
+import android.content.Context;
+import android.graphics.Typeface;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.Toolbar;
+import android.util.AttributeSet;
+import android.widget.TextView;
+
+/**
+ * Created by realitix on 27/07/17.
+ */
+
+public class CenteredToolbar extends Toolbar {
+    private TextView titleView;
+
+    public CenteredToolbar(Context context) {
+        super(context);
+    }
+
+    public CenteredToolbar(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public CenteredToolbar(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int l, int t, int r, int b) {
+        super.onLayout(changed, l, t, r, b);
+        if (titleView != null) {
+            titleView.setX((getWidth() - titleView.getWidth()) / 2);
+        }
+    }
+
+    @Override
+    public void setTitle(CharSequence title) {
+        if (title.length() <= 0) {
+            if (titleView != null && titleView.getParent() == this) {
+                removeView(titleView);
+            }
+            return;
+        }
+
+        if (titleView == null) {
+            titleView = new TextView(getContext());
+        }
+
+        if ( titleView.getParent() != this ) {
+            addView(titleView, new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
+        }
+
+        titleView.setText(title);
+    }
+
+    @Override
+    public void setTitleTextColor(int color) {
+        titleView.setTextColor(color);
+    }
+
+    public void setTitleSize(float size) {
+        titleView.setTextSize(size);
+    }
+
+    public void setTitleTypeface(Typeface font) {
+        titleView.setTypeface(font);
+    }
+}

--- a/app/src/main/java/com/jasonette/seed/Lib/JasonToolbar.java
+++ b/app/src/main/java/com/jasonette/seed/Lib/JasonToolbar.java
@@ -8,6 +8,10 @@ import android.util.AttributeSet;
 import android.view.Gravity;
 import android.widget.TextView;
 
+import com.jasonette.seed.Helper.JasonHelper;
+
+import org.json.JSONObject;
+
 /**
  * Created by realitix on 27/07/17.
  */
@@ -16,7 +20,6 @@ public class JasonToolbar extends Toolbar {
     private TextView titleView;
     private int alignment = Gravity.LEFT;
     private int leftOffset = 0;
-    private int rightOffset = 0;
     private int topOffset = 0;
 
     public JasonToolbar(Context context) {
@@ -40,16 +43,8 @@ public class JasonToolbar extends Toolbar {
             if (alignment == Gravity.CENTER) {
                 titleView.setX((getWidth() - titleView.getWidth()) / 2);
             }
-            else if (alignment == Gravity.RIGHT) {
-
-                if (getMenu().size() != 0) {
-                    offset = 150;
-                }
-
-                titleView.setX((getWidth() - titleView.getWidth()) - offset - rightOffset);
-            }
-            else {
-                titleView.setX(offset + leftOffset); // LEFT
+            else { // LEFT
+                titleView.setX(offset + leftOffset);
             }
 
             titleView.setTranslationY(topOffset);
@@ -76,6 +71,10 @@ public class JasonToolbar extends Toolbar {
         titleView.setText(title);
     }
 
+    public void setTitleFont(JSONObject style) {
+        JasonHelper.setTextViewFont(titleView, style, getContext());
+    }
+
     @Override
     public void setTitleTextColor(int color) {
         titleView.setTextColor(color);
@@ -95,10 +94,6 @@ public class JasonToolbar extends Toolbar {
 
     public void setLeftOffset(int offset) {
         leftOffset = offset;
-    }
-
-    public void setRightOffset(int offset) {
-        this.rightOffset = offset;
     }
 
     public void setTopOffset(int offset) {

--- a/app/src/main/java/com/jasonette/seed/Lib/JasonToolbar.java
+++ b/app/src/main/java/com/jasonette/seed/Lib/JasonToolbar.java
@@ -6,8 +6,11 @@ import android.support.annotation.Nullable;
 import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
 import android.view.Gravity;
+import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.bumptech.glide.Glide;
+import com.jasonette.seed.Component.JasonImageComponent;
 import com.jasonette.seed.Helper.JasonHelper;
 
 import org.json.JSONObject;
@@ -18,9 +21,12 @@ import org.json.JSONObject;
 
 public class JasonToolbar extends Toolbar {
     private TextView titleView;
-    private int alignment = Gravity.LEFT;
-    private int leftOffset = 0;
-    private int topOffset = 0;
+    private ImageView logoView;
+    private int alignment = -1;
+    private int leftOffset;
+    private int topOffset;
+    private int imageWidth;
+    private int imageHeight;
 
     public JasonToolbar(Context context) {
         super(context);
@@ -35,24 +41,13 @@ public class JasonToolbar extends Toolbar {
     }
 
     @Override
-    protected void onLayout(boolean changed, int l, int t, int r, int b) {
-        super.onLayout(changed, l, t, r, b);
-        if (titleView != null) {
-            int offset = 50;
-
-            if (alignment == Gravity.CENTER) {
-                titleView.setX((getWidth() - titleView.getWidth()) / 2);
-            }
-            else { // LEFT
-                titleView.setX(offset + leftOffset);
-            }
-
-            titleView.setTranslationY(topOffset);
-        }
-    }
-
-    @Override
     public void setTitle(CharSequence title) {
+        // remove image view before inserting title view
+        if (logoView != null && logoView.getParent() == this) {
+            removeView(logoView);
+        }
+
+        // remove title if empty
         if (title.length() <= 0) {
             if (titleView != null && titleView.getParent() == this) {
                 removeView(titleView);
@@ -60,15 +55,54 @@ public class JasonToolbar extends Toolbar {
             return;
         }
 
+        // create title only on the first call
         if (titleView == null) {
             titleView = new TextView(getContext());
         }
 
-        if ( titleView.getParent() != this ) {
+        // insert into toolbar
+        if (titleView.getParent() != this) {
             addView(titleView, new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
         }
 
+        // manage positioning
+        Toolbar.LayoutParams params = new Toolbar.LayoutParams(Toolbar.LayoutParams.WRAP_CONTENT, Toolbar.LayoutParams.WRAP_CONTENT);
+        params.gravity = (alignment == -1) ? Gravity.LEFT : alignment;
+        params.leftMargin = leftOffset;
+        params.topMargin = topOffset;
+        titleView.setLayoutParams(params);
+
+        // set text
         titleView.setText(title);
+    }
+
+    public void setImage(JSONObject url) {
+        // remove title view before inserting image view
+        if (titleView != null && titleView.getParent() == this) {
+            removeView(titleView);
+        }
+
+        // create the image view only on the first call
+        if (logoView == null) {
+            logoView = new ImageView(getContext());
+        }
+
+        // insert into toolbar
+        if (logoView.getParent() != this) {
+            addView(logoView);
+        }
+
+        // manage positioning
+        Toolbar.LayoutParams params = new Toolbar.LayoutParams(imageWidth, imageHeight);
+        params.gravity = (alignment == -1) ? Gravity.CENTER : alignment;
+        params.leftMargin = leftOffset;
+        params.topMargin = topOffset;
+        logoView.setLayoutParams(params);
+
+        // load image with glide
+        Glide.with(getContext())
+                .load(JasonImageComponent.resolve_url(url, getContext()))
+                .into(logoView);
     }
 
     public void setTitleFont(JSONObject style) {
@@ -97,6 +131,14 @@ public class JasonToolbar extends Toolbar {
     }
 
     public void setTopOffset(int offset) {
-        this.topOffset = offset;
+        topOffset = offset;
+    }
+
+    public void setImageHeight(int height) {
+        imageHeight = height;
+    }
+
+    public void setImageWidth(int width) {
+        imageWidth = width;
     }
 }

--- a/app/src/main/java/com/jasonette/seed/Lib/JasonToolbar.java
+++ b/app/src/main/java/com/jasonette/seed/Lib/JasonToolbar.java
@@ -5,24 +5,29 @@ import android.graphics.Typeface;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.Toolbar;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.widget.TextView;
 
 /**
  * Created by realitix on 27/07/17.
  */
 
-public class CenteredToolbar extends Toolbar {
+public class JasonToolbar extends Toolbar {
     private TextView titleView;
+    private int alignment = Gravity.LEFT;
+    private int leftOffset = 0;
+    private int rightOffset = 0;
+    private int topOffset = 0;
 
-    public CenteredToolbar(Context context) {
+    public JasonToolbar(Context context) {
         super(context);
     }
 
-    public CenteredToolbar(Context context, @Nullable AttributeSet attrs) {
+    public JasonToolbar(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
     }
 
-    public CenteredToolbar(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    public JasonToolbar(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
     }
 
@@ -30,7 +35,24 @@ public class CenteredToolbar extends Toolbar {
     protected void onLayout(boolean changed, int l, int t, int r, int b) {
         super.onLayout(changed, l, t, r, b);
         if (titleView != null) {
-            titleView.setX((getWidth() - titleView.getWidth()) / 2);
+            int offset = 50;
+
+            if (alignment == Gravity.CENTER) {
+                titleView.setX((getWidth() - titleView.getWidth()) / 2);
+            }
+            else if (alignment == Gravity.RIGHT) {
+
+                if (getMenu().size() != 0) {
+                    offset = 150;
+                }
+
+                titleView.setX((getWidth() - titleView.getWidth()) - offset - rightOffset);
+            }
+            else {
+                titleView.setX(offset + leftOffset); // LEFT
+            }
+
+            titleView.setTranslationY(topOffset);
         }
     }
 
@@ -65,5 +87,21 @@ public class CenteredToolbar extends Toolbar {
 
     public void setTitleTypeface(Typeface font) {
         titleView.setTypeface(font);
+    }
+
+    public void setAlignment(int alignment) {
+        this.alignment = alignment;
+    }
+
+    public void setLeftOffset(int offset) {
+        leftOffset = offset;
+    }
+
+    public void setRightOffset(int offset) {
+        this.rightOffset = offset;
+    }
+
+    public void setTopOffset(int offset) {
+        this.topOffset = offset;
     }
 }


### PR DESCRIPTION
To proceed, we override the Toolbar class by adding a TextView for the
title. It works like the Toolbar but it gives us full control over the TextView.