### PR TITLE
Implement Relative urls

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Action/JasonCacheAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonCacheAction.java
@@ -17,12 +17,12 @@ public class JasonCacheAction {
 
             // Merge with the new input
             JSONObject options = action.getJSONObject("options");
-            JSONObject old_cache = new JSONObject(pref.getString(activity.url, "{}"));
+            JSONObject old_cache = new JSONObject(pref.getString(activity.getUrl(), "{}"));
             JSONObject new_cache = JasonHelper.merge(old_cache, options);
 
             // Update SharedPreferences
             String stringified_cache = new_cache.toString();
-            editor.putString(activity.url, stringified_cache);
+            editor.putString(activity.getUrl(), stringified_cache);
             editor.commit();
 
             // Update model
@@ -43,7 +43,7 @@ public class JasonCacheAction {
             JasonViewActivity activity = (JasonViewActivity) context;
             SharedPreferences pref = context.getSharedPreferences("cache", 0);
             SharedPreferences.Editor editor = pref.edit();
-            editor.remove(activity.url);
+            editor.remove(activity.getUrl());
             editor.commit();
 
             // Update model

--- a/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
@@ -1,19 +1,17 @@
 package com.jasonette.seed.Action;
 
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.util.Base64;
 import android.util.Log;
 
-import com.jasonette.seed.Core.JasonViewActivity;
 import com.jasonette.seed.Helper.JasonHelper;
-import com.jasonette.seed.Launcher.Launcher;
 
 import org.json.JSONObject;
+
 import java.io.IOException;
-import java.net.URI;
+import java.net.URL;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -31,7 +29,7 @@ public class JasonNetworkAction {
         try{
             final JSONObject options = action.getJSONObject("options");
             if(options.has("url")){
-                String url = options.getString("url");
+                URL url = JasonHelper.resolveUrl(options.getString("url"), context);
 
                 // method
                 String method = "GET";
@@ -43,8 +41,7 @@ public class JasonNetworkAction {
                 SharedPreferences pref = context.getSharedPreferences("session", 0);
                 JSONObject session = null;
 
-                URI uri_for_session = new URI(url.toLowerCase());
-                String session_domain = uri_for_session.getHost();
+                String session_domain = url.getHost();
 
                 if(pref.contains(session_domain)){
                     String str = pref.getString(session_domain, null);
@@ -80,7 +77,7 @@ public class JasonNetworkAction {
                 }
 
                 if(method.equalsIgnoreCase("get")) {
-                    Uri.Builder b = Uri.parse(url).buildUpon();
+                    Uri.Builder b = Uri.parse(url.toString()).buildUpon();
 
                     // Attach Params from Session
                     if(session != null && session.has("body")) {
@@ -100,7 +97,7 @@ public class JasonNetworkAction {
                         Iterator<String> keysIterator = d.keys();
                         try {
                             while (keysIterator.hasNext()) {
-                                String key = (String) keysIterator.next();
+                                String key = keysIterator.next();
                                 String val = d.getString(key);
                                 b.appendQueryParameter(key, val);
                             }
@@ -108,9 +105,6 @@ public class JasonNetworkAction {
 
                         }
                     }
-
-                    Uri uri = b.build();
-                    url = uri.toString();
 
                     request = builder
                             .url(url)
@@ -133,7 +127,7 @@ public class JasonNetworkAction {
                             Iterator<String> keysIterator = d.keys();
                             try {
                                 while (keysIterator.hasNext()) {
-                                    String key = (String) keysIterator.next();
+                                    String key = keysIterator.next();
                                     String val = d.getString(key);
                                     bodyBuilder.add(key, val);
                                 }

--- a/app/src/main/java/com/jasonette/seed/Component/JasonComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonComponent.java
@@ -2,19 +2,18 @@ package com.jasonette.seed.Component;
 
 import android.content.Context;
 import android.graphics.drawable.GradientDrawable;
-import android.os.Build;
 import android.support.v4.content.ContextCompat;
-import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
 import com.jasonette.seed.Core.JasonViewActivity;
 import com.jasonette.seed.Helper.JasonHelper;
-import com.jasonette.seed.R;
 import com.jasonette.seed.Section.JasonLayout;
 
 import org.json.JSONObject;
+
+import timber.log.Timber;
 
 public class JasonComponent {
     public static View build(View view, final JSONObject component, final JSONObject parent, final Context root_context) {
@@ -150,7 +149,7 @@ public class JasonComponent {
             return view;
 
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
             return new View(root_context);
         }
     }
@@ -181,7 +180,7 @@ public class JasonComponent {
                         }
                     }
                 } catch (Exception e) {
-                    Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                    Timber.w(e);
                 }
             }
         };

--- a/app/src/main/java/com/jasonette/seed/Component/JasonComponentFactory.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonComponentFactory.java
@@ -1,13 +1,14 @@
 package com.jasonette.seed.Component;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.TextView;
 import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Map;
+
+import timber.log.Timber;
 
 public class JasonComponentFactory {
     Map<String, Integer> signature_to_type = new HashMap<String,Integer>();
@@ -47,7 +48,7 @@ public class JasonComponentFactory {
 
         }
         catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
         return new View(context);

--- a/app/src/main/java/com/jasonette/seed/Component/JasonImageComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonImageComponent.java
@@ -18,11 +18,11 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.LazyHeaders;
 import com.bumptech.glide.load.resource.drawable.GlideDrawable;
-import com.bumptech.glide.load.resource.gif.GifDrawable;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.BitmapImageViewTarget;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.jasonette.seed.Helper.JasonHelper;
+
 import org.json.JSONObject;
 
 import java.net.URI;
@@ -79,7 +79,7 @@ public class JasonImageComponent {
                 return url;
             } else {
                 LazyHeaders.Builder builder = JasonImageComponent.prepare(component, context);
-                return new GlideUrl(url, builder.build());
+                return new GlideUrl(JasonHelper.resolveUrl(url, context), builder.build());
             }
         } catch (Exception e){
             Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());

--- a/app/src/main/java/com/jasonette/seed/Component/JasonMapComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonMapComponent.java
@@ -3,7 +3,6 @@ package com.jasonette.seed.Component;
 import android.content.Context;
 import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -23,6 +22,8 @@ import com.jasonette.seed.Helper.JasonHelper;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import timber.log.Timber;
 
 
 public class JasonMapComponent {
@@ -64,7 +65,7 @@ public class JasonMapComponent {
                 mapview.getMapAsync(new MapReadyHandler(component, mapview, context));
                 return mapview;
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         } else {
             try {
@@ -78,7 +79,7 @@ public class JasonMapComponent {
                 ((MapView)view).onResume(); // Trigger onResume
                 return view;
             } catch (Exception e){
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
         return new View(context);
@@ -95,7 +96,7 @@ public class JasonMapComponent {
                 longitude = Double.parseDouble(r[1]);
             }
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
         return new LatLng(latitude, longitude);
     }
@@ -168,7 +169,7 @@ public class JasonMapComponent {
                     }
                 }
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
     }

--- a/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
@@ -3,7 +3,6 @@ package com.jasonette.seed.Core;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.util.Log;
 
 import com.jasonette.seed.Helper.JasonHelper;
 import com.jasonette.seed.Launcher.Launcher;
@@ -25,6 +24,7 @@ import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import timber.log.Timber;
 
 public class JasonModel{
     public String url;
@@ -56,7 +56,7 @@ public class JasonModel{
             try {
                 this.params = new JSONObject(intent.getStringExtra("params"));
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 
@@ -71,7 +71,7 @@ public class JasonModel{
             try {
                 this.cache = new JSONObject(str);
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 
@@ -86,7 +86,7 @@ public class JasonModel{
                 this.session = new JSONObject(str);
             }
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         };
 
         try {
@@ -94,7 +94,7 @@ public class JasonModel{
             v.put("url", this.url);
             ((Launcher)(this.view.getApplicationContext())).setEnv("view", v);
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         };
     }
 
@@ -125,7 +125,7 @@ public class JasonModel{
             t.start();
 
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -184,7 +184,7 @@ public class JasonModel{
                 }
             });
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -215,7 +215,7 @@ public class JasonModel{
             try {
                 latch.await();
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 
@@ -255,7 +255,7 @@ public class JasonModel{
                 }
             }
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -289,13 +289,13 @@ public class JasonModel{
                     try {
                         resolve_and_build(resolved_jason.toString());
                     } catch (Exception e) {
-                        Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
                 }
             });
             JasonParser.getInstance(this.view).parse("json", refs, to_resolve, this.view);
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
     }
@@ -323,13 +323,13 @@ public class JasonModel{
                     try {
                         resolve_and_build(resolved_jason.toString());
                     } catch (Exception e) {
-                        Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
                 }
             });
             JasonParser.getInstance(this.view).parse("json", refs, to_resolve, this.view);
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
     }
@@ -363,7 +363,7 @@ public class JasonModel{
                 state.put("$env", ((Launcher)(this.view.getApplicationContext())).getEnv());
                 state.put("$params", params);
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         } else {
 

--- a/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
@@ -42,7 +42,7 @@ public class JasonParser {
                 instance.juice.executeVoidScript(js);
                 instance.juice.getLocker().release();
             } catch (Exception e){
-                Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
         return instance;
@@ -93,7 +93,7 @@ public class JasonParser {
                         listener.onFinished(res);
 
                     } catch (Exception e){
-                        Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
 
                     // thread handling - release handle
@@ -101,7 +101,7 @@ public class JasonParser {
                }
             }).start();
         } catch (Exception e){
-            Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 }

--- a/app/src/main/java/com/jasonette/seed/Core/JasonRequire.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonRequire.java
@@ -21,6 +21,7 @@ import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
+import timber.log.Timber;
 
 public class JasonRequire implements Runnable{
     final String URL;
@@ -63,7 +64,7 @@ public class JasonRequire implements Runnable{
             Thread t = new Thread(r);
             t.start();
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
             latch.countDown();
         }
     }
@@ -140,13 +141,13 @@ public class JasonRequire implements Runnable{
                         }
                         latch.countDown();
                     } catch (JSONException e) {
-                        Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
                 }
             });
 
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 }

--- a/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
@@ -7,7 +7,6 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.WindowManager;
 
@@ -22,10 +21,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import timber.log.Timber;
 
 public class JasonHelper {
     public static JSONObject style(JSONObject component, Context root_context) {
@@ -45,7 +48,7 @@ public class JasonHelper {
                 }
             }
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
         try {
@@ -60,7 +63,7 @@ public class JasonHelper {
                 }
             }
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
         return style;
     }
@@ -76,7 +79,7 @@ public class JasonHelper {
             }
             return stub;
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
             return new JSONObject();
         }
     }
@@ -100,7 +103,7 @@ public class JasonHelper {
                 LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
             }
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -115,7 +118,7 @@ public class JasonHelper {
                 return new Object();
             }
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
             return new Object();
         }
     }
@@ -128,7 +131,7 @@ public class JasonHelper {
                 list.add(jsonArray.getJSONObject(i));
             }
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
         return list;
     }
@@ -278,7 +281,7 @@ public class JasonHelper {
                 ret = jr;
             }
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
             return new JSONObject();
         }
         return ret;
@@ -297,7 +300,7 @@ public class JasonHelper {
             intent.putExtra("action", alert_action.toString());
             LocalBroadcastManager.getInstance(context).sendBroadcast(intent);
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -355,7 +358,7 @@ public class JasonHelper {
 
             ((Launcher) ((JasonViewActivity) context).getApplicationContext()).once(name, handler);
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
         if (intent != null) {
@@ -386,10 +389,27 @@ public class JasonHelper {
             callback.put("options", callback_options);
             return callback;
         } catch (Exception e) {
-            Log.d("Error", "wasn't able to preserve stack");
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.e(e, "Error", "wasn't able to preserve stack");
             return callback;
         }
+    }
+
+    /**
+     * Resolve Urls that maybe relative to a base, root url as provided by the context.
+     *
+     * @param url
+     * @param context
+     * @return
+     * @throws MalformedURLException
+     */
+    public static URL resolveUrl(String url, Context context) throws MalformedURLException {
+        // assume relative
+        if (url.startsWith("/")) {
+            URL resolvedUrl =  new URL(new URL(((JasonViewActivity)context).getUrl()), url);
+            return resolvedUrl;
+        }
+        // Validate the URL
+        return new URL(url);
     }
 
 }

--- a/app/src/main/java/com/jasonette/seed/Helper/JasonImageHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Helper/JasonImageHelper.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Environment;
-import android.util.Log;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.model.GlideUrl;
@@ -18,9 +17,10 @@ import org.json.JSONObject;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Iterator;
+
+import timber.log.Timber;
 
 public class JasonImageHelper {
     public interface JasonImageDownloadListener {
@@ -56,7 +56,7 @@ public class JasonImageHelper {
             Uri bitmapUri = Uri.fromFile(file);
             this.listener.onLoaded(this.data, bitmapUri);
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
     }
@@ -121,7 +121,7 @@ public class JasonImageHelper {
 
                                     listener.onLoaded(byteArray, bitmapUri);
                                 } catch (Exception e) {
-                                    Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                                    Timber.w(e);
                                 }
 
                             }
@@ -129,7 +129,7 @@ public class JasonImageHelper {
 
             }
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 }

--- a/app/src/main/java/com/jasonette/seed/Section/ItemAdapter.java
+++ b/app/src/main/java/com/jasonette/seed/Section/ItemAdapter.java
@@ -3,7 +3,6 @@ package com.jasonette.seed.Section;
 import android.content.Context;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,6 +16,8 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
+import timber.log.Timber;
 
 
 /********************************************************
@@ -570,7 +571,7 @@ public class ItemAdapter extends RecyclerView.Adapter <ItemAdapter.ViewHolder>{
                 }
                 view.requestLayout();
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 


### PR DESCRIPTION
Implement relative urls in jasonette
    
This will now resolve url values prefixed with a forward-slash as relative to the url of the jasonette json they are included in.

This works for urls used for mixins as well as images and other uses or urls within Jasonette JSON.

Also included are improvements to error logging to help debug this work and help with future debugging.

This is a reworking of the original PR (https://github.com/Jasonette/JASONETTE-Android/pull/35) by @brad 

Fixes: #151