### PR TITLE
Replace audio recording lib with patched ver

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,8 +42,7 @@ dependencies {
     compile 'com.github.scribejava:scribejava-apis:4.0.0'
     compile 'com.yqritc:recyclerview-flexibledivider:1.4.0'
     compile 'com.commonsware.cwac:cam2:0.7.4'
-    compile 'com.github.adrielcafe:AndroidAudioRecorder:0.2.0'
-    compile 'com.github.adrielcafe:AndroidAudioConverter:0.0.8'
+    compile 'com.github.maks:AndroidAudioRecorder:0.3.0-jasonette'
     compile 'com.github.florent37:singledateandtimepicker:1.0.8'
     compile 'com.jakewharton.timber:timber:4.5.1'
 }


### PR DESCRIPTION
The replacement audio recording lib is patched to record directly into m4a without the need for converting from wav which removes the need for the conversion library that brought in ffmpeg binary depenendency which contributes ~11MB to size of debug apk

This is only intended to be a temporary measure until the record UI can be implemented completely with jasonette syntax with the upcoming events system.

Fixes: #161 