### PR TITLE
Use Android Webview to execute JS within Jasonette

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.4.2'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'jp.wasabeef:glide-transformations:2.0.1'
-    compile 'com.eclipsesource.j2v8:j2v8:4.5.0@aar'
     compile 'com.android.support:recyclerview-v7:25.0.1'
     compile 'com.android.support:design:25.0.1'
     compile 'com.aurelhubert:ahbottomnavigation:2.0.2'

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -43,9 +43,9 @@
             android:theme="@style/CameraTheme"/>
 
         <!-- Uncomment below line and add your Google Maps API key -->
-
-        <meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyBQVtV9PM1djj7ZotagSlxeN2vL6b459lg"/>
-
+        <!--
+               <meta-data android:name="com.google.android.geo.API_KEY" android:value="YOUR GOOGLE MAPS API KEY HERE"/>
+       -->
     </application>
 
 </manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -43,9 +43,9 @@
             android:theme="@style/CameraTheme"/>
 
         <!-- Uncomment below line and add your Google Maps API key -->
-        <!--
-        <meta-data android:name="com.google.android.geo.API_KEY" android:value="YOUR GOOGLE MAPS API KEY HERE"/>
-        -->
+
+        <meta-data android:name="com.google.android.geo.API_KEY" android:value="AIzaSyBQVtV9PM1djj7ZotagSlxeN2vL6b459lg"/>
+
     </application>
 
 </manifest>

--- a/app/src/debug/res/values/bools.xml
+++ b/app/src/debug/res/values/bools.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="enableStethoConsole">true</bool>
+    <bool name="enableStethoConsole">false</bool>
 </resources>

--- a/app/src/main/assets/csv.html
+++ b/app/src/main/assets/csv.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang=en>
+<head>
+    <meta charset=utf-8>
+    <title>Parser</title>
+</head>
+<body>
+    <script src="file:///android_asset/csv" type="text/javascript"></script>
+</body>
+</html>

--- a/app/src/main/assets/parser.html
+++ b/app/src/main/assets/parser.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang=en>
+<head>
+    <meta charset=utf-8>
+    <title>Parser</title>
+</head>
+<body>
+    <script src="file:///android_asset/parser" type="text/javascript"></script>
+</body>
+</html>

--- a/app/src/main/assets/rss.html
+++ b/app/src/main/assets/rss.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang=en>
+<head>
+    <meta charset=utf-8>
+    <title>Parser</title>
+</head>
+<body>
+    <script>
+    // The rss JS script expects a custom global function called "callback" which is injected
+    // into the JS engine by the calling Java code. But using webview means we it can only
+    // inject global object so this shim function just hides that difference from rss script.
+
+        var callback = function(items) {
+          rssResult.callback(JSON.stringify(items));
+        }
+    </script>
+    <script src="file:///android_asset/rss" type="text/javascript"></script>
+</body>
+</html>

--- a/app/src/main/java/com/jasonette/seed/Action/JasonConvertAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonConvertAction.java
@@ -1,28 +1,31 @@
 package com.jasonette.seed.Action;
 
 import android.content.Context;
+import android.webkit.JavascriptInterface;
 
 import com.jasonette.seed.Core.JSEngineHelper;
 import com.jasonette.seed.Helper.JasonHelper;
 
+import org.apache.commons.lang.StringEscapeUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import timber.log.Timber;
 
-//import com.eclipsesource.v8.JavaVoidCallback;
-//import com.eclipsesource.v8.V8;
-//import com.eclipsesource.v8.V8Array;
-//import com.eclipsesource.v8.V8Object;
-
 public class JasonConvertAction {
     private static final String CSV_HTML_ASSET = "csv.html";
     private static final String CONVERT_CSV_FUNCTION_NAME = "csv.run";
-
+    private static final String RSS_HTML_ASSET = "rss.html";
+    private static final String CONVERT_RSS_FUNCTION_NAME = "rss.run";
+    private static final String RSS_RESULT_GLOBAL_OBJECT = "rssResult";
 
     private JSONObject action;
     private Context context;
     private JSONObject event_cache;
-    private JSEngineHelper mJSEngine;
+
+    private JSEngineHelper mCSVJSEngine;
+    private JSEngineHelper mRSSJSEngine;
 
     public void csv(final JSONObject action, final JSONObject data, final JSONObject event, final Context context){
         try {
@@ -38,15 +41,15 @@ public class JasonConvertAction {
                     String script = String.format("%s(\"%s\");", CONVERT_CSV_FUNCTION_NAME, csv_data.toString());
 
                     String html = JasonHelper.read_file(CSV_HTML_ASSET, context);
-                    mJSEngine = new JSEngineHelper(context, html);
-                    mJSEngine.evaluate(script, new JSEngineHelper.WebViewResultListener() {
+                    mCSVJSEngine = new JSEngineHelper(context, html, JSEngineHelper.ASSETS_URL_PREFIX+CSV_HTML_ASSET);
+                    Timber.d("eval script: %s", script);
+                    mCSVJSEngine.evaluate(script, new JSEngineHelper.WebViewResultListener() {
                         @Override
                         public void onResult(Object json) {
                             if (json != null) {
                                 JasonHelper.next("success", action, json.toString(), event, context);
                             } else {
-                                Timber.e("null returned by JS");
-                                JasonHelper.next("error", action, "{}", event, context);
+                                handleError(new Exception("null returned by JS"));
                             }
                         }
                     });
@@ -57,66 +60,64 @@ public class JasonConvertAction {
             }
 
         } catch (Exception e){
-            handle_exception(e);
+            handleError(e);
         }
     }
 
     public void rss(final JSONObject action, final JSONObject data, final JSONObject event, final Context context){
-//        this.action = action;
-//        this.context = context;
-//        event_cache = event;
-//        try{
-//            final JSONObject options = action.getJSONObject("options");
-//            String rss_data = options.getString("data");
-//            String js = JasonHelper.read_file("rss", context);
-//            String timers = JasonHelper.read_file("timers", context);
-//            V8 runtime = V8.createV8Runtime();
-//            runtime.executeVoidScript(js);
-//
-//            // Shim to support javascript timer functions in V8
-//            runtime.registerJavaMethod(new Sleep(), "sleep");
-//            runtime.executeVoidScript(timers);
-//            runtime.executeVoidScript("var timerLoop = makeWindowTimer(this, sleep);");
-//
-//            V8Object rss = runtime.getObject("rss");
-//            V8Array parameters = new V8Array(runtime).push(rss_data.toString());
-//            // Register a callback to receive the RSS JSON data
-//            runtime.registerJavaMethod(new RSSCallback(), "callback");
-//            rss.executeObjectFunction("run", parameters);
-//
-//            // Now we need to kick off the timer loop to get the parsing started
-//            runtime.executeVoidScript("timerLoop()");
-//
-//            parameters.release();
-//            rss.release();
-//            runtime.release();
-//        } catch (Exception e){
-//            handle_exception(e);
-//        }
+        try {
+            this.action = action;
+            this.context = context;
+            event_cache = event;
+
+            final JSONObject options = action.getJSONObject("options");
+
+            if(options.has("data")) {
+                String rss_data = options.getString("data");
+                if (!rss_data.isEmpty()) {
+                    String script = String.format("%s('%s')", CONVERT_RSS_FUNCTION_NAME, StringEscapeUtils.escapeJavaScript(rss_data.toString()));
+
+                    String html = JasonHelper.read_file(RSS_HTML_ASSET, context);
+                    mRSSJSEngine = new JSEngineHelper(context, html,
+                            JSEngineHelper.ASSETS_URL_PREFIX+RSS_HTML_ASSET,
+                            new RssResult(), RSS_RESULT_GLOBAL_OBJECT);
+                    mRSSJSEngine.evaluate(script, new JSEngineHelper.WebViewResultListener() {
+                        @Override
+                        public void onResult(Object json) {
+                            // don't care, result comes via RssResult.callback()
+                        }
+                    });
+                }
+            } else {
+                String result = "[]";
+                JasonHelper.next("success", action, result, event, context);
+            }
+
+        } catch (Exception e){
+            handleError(e);
+        }
     }
 
-    /**
-     * Converts a JSON object to a string using the javascript method `JSON.stringify`
-     * @param runtime     a V8 runtime
-     * @param jsonObject  a JSON object (V8Object)
-     * @return            a String representation of the JSON object
-     */
-//    private String stringify(final V8 runtime, V8Object jsonObject){
-//        V8Array parameters = new V8Array(runtime).push(jsonObject);
-//        V8Object json = runtime.getObject("JSON");
-//        String result = json.executeStringFunction("stringify", parameters);
-//        parameters.release();
-//        jsonObject.release();
-//        json.release();
-//        return result;
-//    }
+
+    class RssResult {
+        @JavascriptInterface
+        public void callback(String items) {
+            try {
+                JSONArray result = new JSONArray(items);
+                JasonHelper.next("success", action, result, event_cache, context);
+            } catch (JSONException e) {
+                Timber.e(e);
+            }
+        }
+    }
 
     /**
      * Handles an exception by passing the error to JasonHelper.next if possible, otherwise log
      * the output
      * @param exc  Exception
      */
-    private void handle_exception(Exception exc){
+    private void handleError(Exception exc){
+        Timber.w(exc, "handling error from running JS");
         try {
             JSONObject error = new JSONObject();
             error.put("data", exc.toString());
@@ -125,37 +126,4 @@ public class JasonConvertAction {
             Timber.e(e);
         }
     }
-
-    /**
-     * Callback to handle the sleep function called from timer javascript code. Simply sleeps for
-     * the number of milliseconds passed in the arguments.
-     */
-//    class Sleep implements JavaVoidCallback {
-//        @Override
-//        public void invoke(V8Object receiver, V8Array parameters) {
-//            try {
-//                Thread.sleep((long)parameters.get(0));
-//            } catch (InterruptedException e) {
-//                handle_exception(e);
-//            }
-//        }
-//    }
-
-    /**
-     * Callback that gets run at the end of RSS parsing. The one parameter is the RSS data, as a
-     * V8Array
-     */
-//    class RSSCallback implements JavaVoidCallback {
-//        @Override
-//        public void invoke(V8Object receiver, V8Array parameters) {
-//            try {
-//                V8Array rss_data = (V8Array) parameters.get(0);
-//                String result = stringify(receiver.getRuntime(), rss_data);
-//
-//                JasonHelper.next("success", action, result, event_cache, context);
-//            } catch (Exception e) {
-//                handle_exception(e);
-//            }
-//        }
-//    }
 }

--- a/app/src/main/java/com/jasonette/seed/Action/JasonConvertAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonConvertAction.java
@@ -3,12 +3,12 @@ package com.jasonette.seed.Action;
 import android.content.Context;
 import android.util.Log;
 
-import com.eclipsesource.v8.JavaVoidCallback;
+//import com.eclipsesource.v8.JavaVoidCallback;
 import com.jasonette.seed.Helper.JasonHelper;
 
-import com.eclipsesource.v8.V8;
-import com.eclipsesource.v8.V8Array;
-import com.eclipsesource.v8.V8Object;
+//import com.eclipsesource.v8.V8;
+//import com.eclipsesource.v8.V8Array;
+//import com.eclipsesource.v8.V8Object;
 import org.json.JSONObject;
 
 import java.lang.Thread;
@@ -19,67 +19,67 @@ public class JasonConvertAction {
     private JSONObject event_cache;
 
     public void csv(final JSONObject action, final JSONObject data, final JSONObject event, final Context context){
-        this.action = action;
-        this.context = context;
-        event_cache = event;
-        try{
-            final JSONObject options = action.getJSONObject("options");
-            String result = "[]";
-            if(options.has("data")) {
-                String csv_data = options.getString("data");
-                if (!csv_data.isEmpty()) {
-                    String js = JasonHelper.read_file("csv", context);
-                    V8 runtime = V8.createV8Runtime();
-                    runtime.executeVoidScript(js);
-                    V8Object csv = runtime.getObject("csv");
-                    V8Array parameters = new V8Array(runtime).push(csv_data.toString());
-                    V8Array val = csv.executeArrayFunction("run", parameters);
-                    parameters.release();
-                    csv.release();
-
-                    result = stringify(runtime, val);
-
-                    runtime.release();
-                }
-            }
-            JasonHelper.next("success", action, result, event, context);
-        } catch (Exception e){
-            handle_exception(e);
-        }
+//        this.action = action;
+//        this.context = context;
+//        event_cache = event;
+//        try{
+//            final JSONObject options = action.getJSONObject("options");
+//            String result = "[]";
+//            if(options.has("data")) {
+//                String csv_data = options.getString("data");
+//                if (!csv_data.isEmpty()) {
+//                    String js = JasonHelper.read_file("csv", context);
+//                    V8 runtime = V8.createV8Runtime();
+//                    runtime.executeVoidScript(js);
+//                    V8Object csv = runtime.getObject("csv");
+//                    V8Array parameters = new V8Array(runtime).push(csv_data.toString());
+//                    V8Array val = csv.executeArrayFunction("run", parameters);
+//                    parameters.release();
+//                    csv.release();
+//
+//                    result = stringify(runtime, val);
+//
+//                    runtime.release();
+//                }
+//            }
+//            JasonHelper.next("success", action, result, event, context);
+//        } catch (Exception e){
+//            handle_exception(e);
+//        }
     }
 
     public void rss(final JSONObject action, final JSONObject data, final JSONObject event, final Context context){
-        this.action = action;
-        this.context = context;
-        event_cache = event;
-        try{
-            final JSONObject options = action.getJSONObject("options");
-            String rss_data = options.getString("data");
-            String js = JasonHelper.read_file("rss", context);
-            String timers = JasonHelper.read_file("timers", context);
-            V8 runtime = V8.createV8Runtime();
-            runtime.executeVoidScript(js);
-
-            // Shim to support javascript timer functions in V8
-            runtime.registerJavaMethod(new Sleep(), "sleep");
-            runtime.executeVoidScript(timers);
-            runtime.executeVoidScript("var timerLoop = makeWindowTimer(this, sleep);");
-
-            V8Object rss = runtime.getObject("rss");
-            V8Array parameters = new V8Array(runtime).push(rss_data.toString());
-            // Register a callback to receive the RSS JSON data
-            runtime.registerJavaMethod(new RSSCallback(), "callback");
-            rss.executeObjectFunction("run", parameters);
-
-            // Now we need to kick off the timer loop to get the parsing started
-            runtime.executeVoidScript("timerLoop()");
-
-            parameters.release();
-            rss.release();
-            runtime.release();
-        } catch (Exception e){
-            handle_exception(e);
-        }
+//        this.action = action;
+//        this.context = context;
+//        event_cache = event;
+//        try{
+//            final JSONObject options = action.getJSONObject("options");
+//            String rss_data = options.getString("data");
+//            String js = JasonHelper.read_file("rss", context);
+//            String timers = JasonHelper.read_file("timers", context);
+//            V8 runtime = V8.createV8Runtime();
+//            runtime.executeVoidScript(js);
+//
+//            // Shim to support javascript timer functions in V8
+//            runtime.registerJavaMethod(new Sleep(), "sleep");
+//            runtime.executeVoidScript(timers);
+//            runtime.executeVoidScript("var timerLoop = makeWindowTimer(this, sleep);");
+//
+//            V8Object rss = runtime.getObject("rss");
+//            V8Array parameters = new V8Array(runtime).push(rss_data.toString());
+//            // Register a callback to receive the RSS JSON data
+//            runtime.registerJavaMethod(new RSSCallback(), "callback");
+//            rss.executeObjectFunction("run", parameters);
+//
+//            // Now we need to kick off the timer loop to get the parsing started
+//            runtime.executeVoidScript("timerLoop()");
+//
+//            parameters.release();
+//            rss.release();
+//            runtime.release();
+//        } catch (Exception e){
+//            handle_exception(e);
+//        }
     }
 
     /**
@@ -88,15 +88,15 @@ public class JasonConvertAction {
      * @param jsonObject  a JSON object (V8Object)
      * @return            a String representation of the JSON object
      */
-    private String stringify(final V8 runtime, V8Object jsonObject){
-        V8Array parameters = new V8Array(runtime).push(jsonObject);
-        V8Object json = runtime.getObject("JSON");
-        String result = json.executeStringFunction("stringify", parameters);
-        parameters.release();
-        jsonObject.release();
-        json.release();
-        return result;
-    }
+//    private String stringify(final V8 runtime, V8Object jsonObject){
+//        V8Array parameters = new V8Array(runtime).push(jsonObject);
+//        V8Object json = runtime.getObject("JSON");
+//        String result = json.executeStringFunction("stringify", parameters);
+//        parameters.release();
+//        jsonObject.release();
+//        json.release();
+//        return result;
+//    }
 
     /**
      * Handles an exception by passing the error to JasonHelper.next if possible, otherwise log
@@ -117,32 +117,32 @@ public class JasonConvertAction {
      * Callback to handle the sleep function called from timer javascript code. Simply sleeps for
      * the number of milliseconds passed in the arguments.
      */
-    class Sleep implements JavaVoidCallback {
-        @Override
-        public void invoke(V8Object receiver, V8Array parameters) {
-            try {
-                Thread.sleep((long)parameters.get(0));
-            } catch (InterruptedException e) {
-                handle_exception(e);
-            }
-        }
-    }
+//    class Sleep implements JavaVoidCallback {
+//        @Override
+//        public void invoke(V8Object receiver, V8Array parameters) {
+//            try {
+//                Thread.sleep((long)parameters.get(0));
+//            } catch (InterruptedException e) {
+//                handle_exception(e);
+//            }
+//        }
+//    }
 
     /**
      * Callback that gets run at the end of RSS parsing. The one parameter is the RSS data, as a
      * V8Array
      */
-    class RSSCallback implements JavaVoidCallback {
-        @Override
-        public void invoke(V8Object receiver, V8Array parameters) {
-            try {
-                V8Array rss_data = (V8Array) parameters.get(0);
-                String result = stringify(receiver.getRuntime(), rss_data);
-
-                JasonHelper.next("success", action, result, event_cache, context);
-            } catch (Exception e) {
-                handle_exception(e);
-            }
-        }
-    }
+//    class RSSCallback implements JavaVoidCallback {
+//        @Override
+//        public void invoke(V8Object receiver, V8Array parameters) {
+//            try {
+//                V8Array rss_data = (V8Array) parameters.get(0);
+//                String result = stringify(receiver.getRuntime(), rss_data);
+//
+//                JasonHelper.next("success", action, result, event_cache, context);
+//            } catch (Exception e) {
+//                handle_exception(e);
+//            }
+//        }
+//    }
 }

--- a/app/src/main/java/com/jasonette/seed/Action/JasonConvertAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonConvertAction.java
@@ -38,11 +38,12 @@ public class JasonConvertAction {
             if(options.has("data")) {
                 String csv_data = options.getString("data");
                 if (!csv_data.isEmpty()) {
-                    String script = String.format("%s(\"%s\");", CONVERT_CSV_FUNCTION_NAME, csv_data.toString());
+                    // escape newlines, ref: https://stackoverflow.com/a/19909669/85472
+                    String escData = csv_data.toString().replaceAll("(\\r|\\n|\\r\\n)+", "\\\\n");
+                    String script = String.format("%s(\"%s\");", CONVERT_CSV_FUNCTION_NAME, escData);
 
                     String html = JasonHelper.read_file(CSV_HTML_ASSET, context);
                     mCSVJSEngine = new JSEngineHelper(context, html, JSEngineHelper.ASSETS_URL_PREFIX+CSV_HTML_ASSET);
-                    Timber.d("eval script: %s", script);
                     mCSVJSEngine.evaluate(script, new JSEngineHelper.WebViewResultListener() {
                         @Override
                         public void onResult(Object json) {
@@ -75,12 +76,14 @@ public class JasonConvertAction {
             if(options.has("data")) {
                 String rss_data = options.getString("data");
                 if (!rss_data.isEmpty()) {
-                    String script = String.format("%s('%s')", CONVERT_RSS_FUNCTION_NAME, StringEscapeUtils.escapeJavaScript(rss_data.toString()));
+                    String escData = StringEscapeUtils.escapeJavaScript(rss_data.toString());
+                    String script = String.format("%s(\"%s\")", CONVERT_RSS_FUNCTION_NAME, escData);
 
                     String html = JasonHelper.read_file(RSS_HTML_ASSET, context);
                     mRSSJSEngine = new JSEngineHelper(context, html,
                             JSEngineHelper.ASSETS_URL_PREFIX+RSS_HTML_ASSET,
                             new RssResult(), RSS_RESULT_GLOBAL_OBJECT);
+
                     mRSSJSEngine.evaluate(script, new JSEngineHelper.WebViewResultListener() {
                         @Override
                         public void onResult(Object json) {

--- a/app/src/main/java/com/jasonette/seed/Component/JasonComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonComponent.java
@@ -2,19 +2,18 @@ package com.jasonette.seed.Component;
 
 import android.content.Context;
 import android.graphics.drawable.GradientDrawable;
-import android.os.Build;
 import android.support.v4.content.ContextCompat;
-import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
 import com.jasonette.seed.Core.JasonViewActivity;
 import com.jasonette.seed.Helper.JasonHelper;
-import com.jasonette.seed.R;
 import com.jasonette.seed.Section.JasonLayout;
 
 import org.json.JSONObject;
+
+import timber.log.Timber;
 
 public class JasonComponent {
 
@@ -158,7 +157,7 @@ public class JasonComponent {
             return view;
 
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
             return new View(root_context);
         }
     }
@@ -189,7 +188,7 @@ public class JasonComponent {
                         }
                     }
                 } catch (Exception e) {
-                    Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                    Timber.w(e);
                 }
             }
         };

--- a/app/src/main/java/com/jasonette/seed/Component/JasonComponentFactory.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonComponentFactory.java
@@ -1,13 +1,14 @@
 package com.jasonette.seed.Component;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.TextView;
 import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Map;
+
+import timber.log.Timber;
 
 public class JasonComponentFactory {
     Map<String, Integer> signature_to_type = new HashMap<String,Integer>();
@@ -47,7 +48,7 @@ public class JasonComponentFactory {
 
         }
         catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
         return new View(context);

--- a/app/src/main/java/com/jasonette/seed/Component/JasonMapComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonMapComponent.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -30,7 +29,6 @@ import org.json.JSONObject;
 import timber.log.Timber;
 
 import static com.jasonette.seed.Action.JasonGeoAction.COORDS_STRING_FORMAT;
-
 
 public class JasonMapComponent extends JasonComponent {
 
@@ -80,7 +78,7 @@ public class JasonMapComponent extends JasonComponent {
                 mapview.getMapAsync(new MapReadyHandler(component, mapview, context));
                 return mapview;
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         } else {
             try {
@@ -94,7 +92,7 @@ public class JasonMapComponent extends JasonComponent {
                 ((MapView)view).onResume(); // Trigger onResume
                 return view;
             } catch (Exception e){
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
         return new View(context);
@@ -111,7 +109,7 @@ public class JasonMapComponent extends JasonComponent {
                 longitude = Double.parseDouble(r[1]);
             }
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
         return new LatLng(latitude, longitude);
     }
@@ -224,7 +222,7 @@ public class JasonMapComponent extends JasonComponent {
                 });
 
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
     }

--- a/app/src/main/java/com/jasonette/seed/Core/JSEngineHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JSEngineHelper.java
@@ -1,0 +1,107 @@
+package com.jasonette.seed.Core;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.webkit.ValueCallback;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import com.jasonette.seed.Helper.JasonHelper;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import timber.log.Timber;
+
+/**
+ * Provide easy to use way to run JS within a WebView in a preloaded html content context.
+ * This allows repeatedly executing JS scripts with a set of preloaded JS scripts/libraries.
+ */
+
+public class JSEngineHelper {
+
+    private static final String ASSETS_URL_PREFIX = "file:///android_asset/";
+    private static final String TEXT_MIME_TYPE = "text/html";
+    private static final String HISTORY_URL = "";
+    private static final long WEBVIEW_READY_TIMEOUT_MS = 1000;
+
+    private final Handler mMainLoopHandler;
+    private WebView mWebView;
+    private CountDownLatch mWebviewReadyLatch = new CountDownLatch(1);
+
+    public interface WebViewResultListener {
+        void onResult(Object json);
+    }
+
+    public JSEngineHelper(Context context, String html) {
+        mMainLoopHandler = new Handler(context.getMainLooper());
+        mWebView = new WebView(context);
+        WebSettings webSettings = mWebView.getSettings();
+        webSettings.setJavaScriptEnabled(true);
+
+        // If we want to redirect console output...
+        // ref: https://stackoverflow.com/a/40485201/85472
+//                mWebView.setWebChromeClient(new WebChromeClient() {
+//                    @Override
+//                    public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
+//                        Timber.e(consoleMessage.message() + " -- From line "
+//                                + consoleMessage.lineNumber() + " of "
+//                                + consoleMessage.sourceId());
+//                        return super.onConsoleMessage(consoleMessage);
+//                    }
+//                });
+
+        mWebView.setWebViewClient(new WebViewClient(){
+            public void onPageFinished(WebView view, String url){
+                Timber.d("Webview READY");
+                mWebviewReadyLatch.countDown();
+            }
+        });
+        mWebView.loadDataWithBaseURL(ASSETS_URL_PREFIX, html, TEXT_MIME_TYPE, "utf-8", HISTORY_URL);
+    }
+
+    public void evaluate(final String script, final WebViewResultListener listener) {
+        mMainLoopHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    mWebviewReadyLatch.await(WEBVIEW_READY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    Timber.w(e);
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                    mWebView.evaluateJavascript(script, new ValueCallback<String>() {
+                        @Override
+                        public void onReceiveValue(String value) {
+                            if (value != null) {
+                                // The string returned by the webview is a JSONObject or JSONArray or value
+                                // in the case of parser.js we know it will only be a Object.
+                                // BUT the string returned from a webview is also always wrapped in double quotes
+                                // AND has double quotes escaped, eg. "{ \"foo]" : \"bar\"}"
+                                // so we need the 2 replace calls to strip out both
+                                // ref: https://stackoverflow.com/a/14884111/85472
+                                //      https://stackoverflow.com/a/2608682/85472
+                                value = value.replaceAll("^\"|\"$", "").replace("\\\"", "\"");
+                            }
+                            listener.onResult((value != null && !"null".equals(value)) ? JasonHelper.objectify(value) : null);
+                        }
+                    });
+                } else {
+                    /**
+                     * For pre-KitKat+ you should use loadUrl("javascript:<JS Code Here>");
+                     * To then call back to Java you would need to use addJavascriptInterface()
+                     * and have your JS call the interface
+                     **/
+//                  mWebView.loadUrl("javascript:"+javascript);
+                    throw new UnsupportedOperationException("Support for Pre-KitKat pending");
+                }
+            }
+        });
+    }
+
+}

--- a/app/src/main/java/com/jasonette/seed/Core/JSEngineHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JSEngineHelper.java
@@ -105,14 +105,16 @@ public class JSEngineHelper {
 
     public void evaluate(final String script, final WebViewResultListener listener) {
         mResultListener = listener;
+        try {
+            mWebviewReadyLatch.await(WEBVIEW_READY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+            Timber.d("Webview Unlatched");
+        } catch (InterruptedException e) {
+            Timber.w(e);
+        }
         mMainLoopHandler.post(new Runnable() {
             @Override
             public void run() {
-                try {
-                    mWebviewReadyLatch.await(WEBVIEW_READY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) {
-                    Timber.w(e);
-                }
+                Timber.d("Webview Eval: %s", script);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                     mWebView.evaluateJavascript(script, new ValueCallback<String>() {
                         @Override

--- a/app/src/main/java/com/jasonette/seed/Core/JSEngineHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JSEngineHelper.java
@@ -3,7 +3,10 @@ package com.jasonette.seed.Core;
 import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
+import android.webkit.ConsoleMessage;
+import android.webkit.JavascriptInterface;
 import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -11,8 +14,6 @@ import android.webkit.WebViewClient;
 import com.jasonette.seed.Helper.JasonHelper;
 
 import org.apache.commons.lang.StringEscapeUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -30,10 +31,12 @@ public class JSEngineHelper {
 
     private static final String TEXT_MIME_TYPE = "text/html";
     private static final long WEBVIEW_READY_TIMEOUT_MS = 1000;
+    private static final String JASONETTE_SHIM_JS_NAME = "JASONETTE_SHIM";
 
     private final Handler mMainLoopHandler;
     private WebView mWebView;
     private CountDownLatch mWebviewReadyLatch = new CountDownLatch(1);
+    private WebViewResultListener mResultListener;
 
     /**
      *
@@ -63,39 +66,45 @@ public class JSEngineHelper {
      *               regarding need to add annotations to publicly visible methods
      * @param name   Name of the property for the Java object in the JS global scope.
      */
-    public JSEngineHelper(Context context, String html, String url, Object object, String name) {
+    public JSEngineHelper(final Context context, final String html, final String url, final Object object, final String name) {
         mMainLoopHandler = new Handler(context.getMainLooper());
-        mWebView = new WebView(context);
-        WebSettings webSettings = mWebView.getSettings();
-        webSettings.setJavaScriptEnabled(true);
 
-        // If we want to redirect console output...
-        // ref: https://stackoverflow.com/a/40485201/85472
-//                mWebView.setWebChromeClient(new WebChromeClient() {
-//                    @Override
-//                    public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
-//                        Timber.e(consoleMessage.message() + " -- From line "
-//                                + consoleMessage.lineNumber() + " of "
-//                                + consoleMessage.sourceId());
-//                        return super.onConsoleMessage(consoleMessage);
-//                    }
-//                });
+        mMainLoopHandler.post(new Runnable() {
+              @Override
+              public void run() {
+                  mWebView = new WebView(context);
+                  WebSettings webSettings = mWebView.getSettings();
+                  webSettings.setJavaScriptEnabled(true);
 
-        mWebView.setWebViewClient(new WebViewClient(){
-            public void onPageFinished(WebView view, String url){
-                Timber.d("JSEngine Webview READY");
-                mWebviewReadyLatch.countDown();
-            }
+                  mWebView.setWebChromeClient(new WebChromeClient() {
+                      @Override
+                      public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
+                          // Code here if we want to redirect console output...
+                          // ref: https://stackoverflow.com/a/40485201/85472
+                          return super.onConsoleMessage(consoleMessage);
+                      }
+                  });
+
+                  mWebView.setWebViewClient(new WebViewClient(){
+                      public void onPageFinished(WebView view, String url){
+                          Timber.d("JSEngine Webview READY");
+                          mWebviewReadyLatch.countDown();
+                      }
+                  });
+
+                  if (object != null && name != null) {
+                      mWebView.addJavascriptInterface(object, name);
+                  }
+                  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+                      mWebView.addJavascriptInterface(JSEngineHelper.this, JASONETTE_SHIM_JS_NAME);
+                  }
+                  mWebView.loadDataWithBaseURL(ASSETS_URL_PREFIX, html, TEXT_MIME_TYPE, "utf-8", url);
+              }
         });
-
-        if (object != null && name != null) {
-            mWebView.addJavascriptInterface(object, name);
-        }
-
-        mWebView.loadDataWithBaseURL(ASSETS_URL_PREFIX, html, TEXT_MIME_TYPE, "utf-8", url);
     }
 
     public void evaluate(final String script, final WebViewResultListener listener) {
+        mResultListener = listener;
         mMainLoopHandler.post(new Runnable() {
             @Override
             public void run() {
@@ -108,25 +117,7 @@ public class JSEngineHelper {
                     mWebView.evaluateJavascript(script, new ValueCallback<String>() {
                         @Override
                         public void onReceiveValue(String value) {
-                            if (value != null) {
-                                // The string returned by the webview is a JSONObject or JSONArray or value
-                                // in the case of parser.js we know it will only be a Object.
-                                // BUT the string returned from a webview is also always wrapped in double quotes
-                                // AND has double quotes escaped, eg. "{ \"foo]" : \"bar\"}"
-                                // so we need the 2 replace calls to strip out both
-                                //
-                                // WE can't just use StringEscapeUtils.unescapeJava because we need to keep "\n"
-                                // as those maybe being used in strings coming from back in the result from the webview
-                                //
-                                // Finally we need to call replace("\\\"", "\"") Twice as the JS code that runs in the
-                                // webview maybe returning strings that it itself has escaped.
-                                //
-                                // ref: https://stackoverflow.com/a/14884111/85472
-                                //      https://stackoverflow.com/a/2608682/85472
-                                value = value.replaceAll("^\"|\"$", "").replace("\\\"", "\"").replace("\\\"", "\"");
-
-                            }
-                            listener.onResult((value != null && !"null".equals(value)) ? JasonHelper.objectify(value) : null);
+                            notifyResultListener(value);
                         }
                     });
                 } else {
@@ -135,11 +126,38 @@ public class JSEngineHelper {
                      * To then call back to Java you would need to use addJavascriptInterface()
                      * and have your JS call the interface
                      **/
-//                  mWebView.loadUrl("javascript:"+javascript);
-                    throw new UnsupportedOperationException("Support for Pre-KitKat pending");
+
+                    String jsUrl = "javascript:var a = "+script+";"+JASONETTE_SHIM_JS_NAME+".result(JSON.stringify(a));";
+                    mWebView.loadUrl(jsUrl);
                 }
             }
         });
     }
 
+    @JavascriptInterface
+    public void result(String jsResult){
+        notifyResultListener(jsResult);
+    }
+
+    private void notifyResultListener(String value) {
+        if (value != null) {
+            // The string returned by the webview is a JSONObject or JSONArray or value
+            // in the case of parser.js we know it will only be a Object.
+            // BUT the string returned from a webview is also always wrapped in double quotes
+            // AND has double quotes escaped, eg. "{ \"foo]" : \"bar\"}"
+            // so we need the 2 replace calls to strip out both
+            //
+            // WE can't just use StringEscapeUtils.unescapeJava because we need to keep "\n"
+            // as those maybe being used in strings coming from back in the result from the webview
+            //
+            // Finally we need to call replace("\\\"", "\"") Twice as the JS code that runs in the
+            // webview maybe returning strings that it itself has escaped.
+            //
+            // ref: https://stackoverflow.com/a/14884111/85472
+            //      https://stackoverflow.com/a/2608682/85472
+            value = value.replaceAll("^\"|\"$", "").replace("\\\"", "\"").replace("\\\"", "\"");
+        }
+
+        mResultListener.onResult((value != null && !"null".equals(value)) ? JasonHelper.objectify(value) : null);
+    }
 }

--- a/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
@@ -27,6 +27,8 @@ import okhttp3.Response;
 import timber.log.Timber;
 
 public class JasonModel{
+    public static final String JASON_PROP_NAME = "$jason";
+
     public String url;
     public JSONObject jason;
     public JSONObject rendered;

--- a/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
@@ -3,7 +3,6 @@ package com.jasonette.seed.Core;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
-import android.util.Log;
 
 import com.jasonette.seed.Helper.JasonHelper;
 import com.jasonette.seed.Launcher.Launcher;
@@ -25,6 +24,7 @@ import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import timber.log.Timber;
 
 public class JasonModel{
     public String url;
@@ -56,7 +56,7 @@ public class JasonModel{
             try {
                 this.params = new JSONObject(intent.getStringExtra("params"));
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 
@@ -71,7 +71,7 @@ public class JasonModel{
             try {
                 this.cache = new JSONObject(str);
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 
@@ -86,7 +86,7 @@ public class JasonModel{
                 this.session = new JSONObject(str);
             }
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         };
 
         try {
@@ -94,7 +94,7 @@ public class JasonModel{
             v.put("url", this.url);
             ((Launcher)(this.view.getApplicationContext())).setEnv("view", v);
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         };
     }
 
@@ -125,7 +125,7 @@ public class JasonModel{
             t.start();
 
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -184,7 +184,7 @@ public class JasonModel{
                 }
             });
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -215,7 +215,7 @@ public class JasonModel{
             try {
                 latch.await();
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 
@@ -255,7 +255,7 @@ public class JasonModel{
                 }
             }
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 
@@ -289,13 +289,13 @@ public class JasonModel{
                     try {
                         resolve_and_build(resolved_jason.toString());
                     } catch (Exception e) {
-                        Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
                 }
             });
             JasonParser.getInstance(this.view).parse("json", refs, to_resolve, this.view);
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
     }
@@ -323,13 +323,13 @@ public class JasonModel{
                     try {
                         resolve_and_build(resolved_jason.toString());
                     } catch (Exception e) {
-                        Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
                 }
             });
             JasonParser.getInstance(this.view).parse("json", refs, to_resolve, this.view);
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
     }
@@ -363,7 +363,7 @@ public class JasonModel{
                 state.put("$env", ((Launcher)(this.view.getApplicationContext())).getEnv());
                 state.put("$params", params);
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         } else {
 

--- a/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
@@ -1,42 +1,29 @@
 package com.jasonette.seed.Core;
 
 import android.content.Context;
-import android.os.Build;
-import android.os.Handler;
-import android.webkit.ValueCallback;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
 
 import com.jasonette.seed.Helper.JasonHelper;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import timber.log.Timber;
 
 public class JasonParser {
+
+
     private static final String PARSER_HTML_ASSET = "parser.html";
-    private static final String ASSETS_URL_PREFIX = "file:///android_asset/";
-    private static final String TEXT_MIME_TYPE = "text/html";
-    private static final String HISTORY_URL = "";
     private static final String JSON_DATA_TYPE_VALUE = "json";
     private static final String PARSER_JSON_FUNCTION_NAME = "parser.json";
     private static final String PARSER_HTML_FUNCTION_NAME = "parser.html";
     private static final long WEBVIEW_READY_TIMEOUT_MS = 1000;
 
     private static JasonParser instance = null;
-    private Handler mHandler;
-    private CountDownLatch mWebviewReadyLatch = new CountDownLatch(1);
+    private static JSEngineHelper mJSEngine;
 
     private JasonParser(){
         this.listener = null;
     }
-
-    static WebView mWebView;
 
     public interface JasonParserListener {
         void onFinished(JSONObject json);
@@ -47,40 +34,14 @@ public class JasonParser {
         this.listener = listener;
     }
 
-
-
     public static JasonParser getInstance(Context context){
         if(instance == null)
         {
             instance = new JasonParser();
-            instance.mHandler = new Handler();
             try {
-                String html = JasonHelper.read_file(PARSER_HTML_ASSET, context);
+                String parserHtml = JasonHelper.read_file(PARSER_HTML_ASSET, context);
+                mJSEngine = new JSEngineHelper(context, parserHtml);
 
-                mWebView = new WebView(context);
-                WebSettings webSettings = mWebView.getSettings();
-                webSettings.setJavaScriptEnabled(true);
-
-                // If we want to redirect console output...
-                // ref: https://stackoverflow.com/a/40485201/85472
-//                mWebView.setWebChromeClient(new WebChromeClient() {
-//                    @Override
-//                    public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
-//                        Timber.e(consoleMessage.message() + " -- From line "
-//                                + consoleMessage.lineNumber() + " of "
-//                                + consoleMessage.sourceId());
-//                        return super.onConsoleMessage(consoleMessage);
-//                    }
-//                });
-
-                mWebView.setWebViewClient(new WebViewClient(){
-                    public void onPageFinished(WebView view, String url){
-                        Timber.d("Parser webview READY");
-                        instance.mWebviewReadyLatch.countDown();
-                    }
-                });
-
-                mWebView.loadDataWithBaseURL(ASSETS_URL_PREFIX, html, TEXT_MIME_TYPE, "utf-8", HISTORY_URL);
             } catch (Exception e){
                 Timber.w(e);
             }
@@ -113,45 +74,10 @@ public class JasonParser {
             }
             script = String.format("%s(%s, %s, true);",PARSER_HTML_FUNCTION_NAME, templateJson, raw_data);
         }
-        mHandler.post(new Runnable() {
-
+        mJSEngine.evaluate(script, new JSEngineHelper.WebViewResultListener() {
             @Override
-            public void run() {
-                try {
-                    mWebviewReadyLatch.await(WEBVIEW_READY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) {
-                    Timber.w(e);
-                }
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    mWebView.evaluateJavascript(script, new ValueCallback<String>() {
-                        @Override
-                        public void onReceiveValue(String value) {
-                            try {
-                                if (value != null) {
-                                    // The string returned by the webview is a JSONObject or JSONArray or value
-                                    // in the case of parser.js we know it will only be a Object.
-                                    // BUT the string returned from a webview is also always wrapped in double quotes
-                                    // AND has double quotes escaped, eg. "{ \"foo]" : \"bar\"}"
-                                    // so we need the 2 replace calls to strip out both
-                                    // ref: https://stackoverflow.com/a/14884111/85472
-                                    //      https://stackoverflow.com/a/2608682/85472
-                                    value = value.replaceAll("^\"|\"$", "").replace("\\\"", "\"");
-                                }
-                                listener.onFinished((value != null && !"null".equals(value)) ? new JSONObject(value) : null);
-                            } catch (JSONException e) {
-                                Timber.e(e);
-                            }
-                        }
-                    });
-                } else {
-                    /**
-                     * For pre-KitKat+ you should use loadUrl("javascript:<JS Code Here>");
-                     * To then call back to Java you would need to use addJavascriptInterface()
-                     * and have your JS call the interface
-                     **/
-//                mWebView.loadUrl("javascript:"+javascript);
-                    throw new UnsupportedOperationException("Support for Pre-KitKat pending");
-                }
+            public void onResult(Object json) {
+                listener.onFinished((JSONObject) json);
             }
         });
     }

--- a/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
@@ -16,7 +16,6 @@ public class JasonParser {
     private static final String JSON_DATA_TYPE_VALUE = "json";
     private static final String PARSER_JSON_FUNCTION_NAME = "parser.json";
     private static final String PARSER_HTML_FUNCTION_NAME = "parser.html";
-    private static final long WEBVIEW_READY_TIMEOUT_MS = 1000;
 
     private static JasonParser instance = null;
     private static JSEngineHelper mJSEngine;
@@ -40,7 +39,7 @@ public class JasonParser {
             instance = new JasonParser();
             try {
                 String parserHtml = JasonHelper.read_file(PARSER_HTML_ASSET, context);
-                mJSEngine = new JSEngineHelper(context, parserHtml);
+                mJSEngine = new JSEngineHelper(context, parserHtml, JSEngineHelper.ASSETS_URL_PREFIX+PARSER_HTML_ASSET);
 
             } catch (Exception e){
                 Timber.w(e);

--- a/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
@@ -42,7 +42,7 @@ public class JasonParser {
                 instance.juice.executeVoidScript(js);
                 instance.juice.getLocker().release();
             } catch (Exception e){
-                Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
         return instance;
@@ -93,7 +93,7 @@ public class JasonParser {
                         listener.onFinished(res);
 
                     } catch (Exception e){
-                        Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
 
                     // thread handling - release handle
@@ -101,7 +101,7 @@ public class JasonParser {
                }
             }).start();
         } catch (Exception e){
-            Timber.w(e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 }

--- a/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonParser.java
@@ -1,31 +1,48 @@
 package com.jasonette.seed.Core;
 
 import android.content.Context;
+import android.os.Build;
+import android.os.Handler;
+import android.webkit.ValueCallback;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
-import com.eclipsesource.v8.V8;
-import com.eclipsesource.v8.V8Array;
-import com.eclipsesource.v8.V8Object;
 import com.jasonette.seed.Helper.JasonHelper;
 
+import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import timber.log.Timber;
 
 public class JasonParser {
-    static JSONObject res;
-    private static Context context;
+    private static final String PARSER_HTML_ASSET = "parser.html";
+    private static final String ASSETS_URL_PREFIX = "file:///android_asset/";
+    private static final String TEXT_MIME_TYPE = "text/html";
+    private static final String HISTORY_URL = "";
+    private static final String JSON_DATA_TYPE_VALUE = "json";
+    private static final String PARSER_JSON_FUNCTION_NAME = "parser.json";
+    private static final String PARSER_HTML_FUNCTION_NAME = "parser.html";
+    private static final long WEBVIEW_READY_TIMEOUT_MS = 1000;
 
     private static JasonParser instance = null;
+    private Handler mHandler;
+    private CountDownLatch mWebviewReadyLatch = new CountDownLatch(1);
 
     private JasonParser(){
         this.listener = null;
     }
 
+    static WebView mWebView;
+
     public interface JasonParserListener {
-        public void onFinished(JSONObject json);
+        void onFinished(JSONObject json);
     }
+
     private JasonParserListener listener;
-    private V8 juice;
     public void setParserListener(JasonParserListener listener){
         this.listener = listener;
     }
@@ -36,11 +53,34 @@ public class JasonParser {
         if(instance == null)
         {
             instance = new JasonParser();
+            instance.mHandler = new Handler();
             try {
-                String js = JasonHelper.read_file("parser", context);
-                instance.juice = V8.createV8Runtime();
-                instance.juice.executeVoidScript(js);
-                instance.juice.getLocker().release();
+                String html = JasonHelper.read_file(PARSER_HTML_ASSET, context);
+
+                mWebView = new WebView(context);
+                WebSettings webSettings = mWebView.getSettings();
+                webSettings.setJavaScriptEnabled(true);
+
+                // If we want to redirect console output...
+                // ref: https://stackoverflow.com/a/40485201/85472
+//                mWebView.setWebChromeClient(new WebChromeClient() {
+//                    @Override
+//                    public boolean onConsoleMessage(ConsoleMessage consoleMessage) {
+//                        Timber.e(consoleMessage.message() + " -- From line "
+//                                + consoleMessage.lineNumber() + " of "
+//                                + consoleMessage.sourceId());
+//                        return super.onConsoleMessage(consoleMessage);
+//                    }
+//                });
+
+                mWebView.setWebViewClient(new WebViewClient(){
+                    public void onPageFinished(WebView view, String url){
+                        Timber.d("Parser webview READY");
+                        instance.mWebviewReadyLatch.countDown();
+                    }
+                });
+
+                mWebView.loadDataWithBaseURL(ASSETS_URL_PREFIX, html, TEXT_MIME_TYPE, "utf-8", HISTORY_URL);
             } catch (Exception e){
                 Timber.w(e);
             }
@@ -48,76 +88,72 @@ public class JasonParser {
         return instance;
     }
 
-
+    /**
+     * Run call methods in parser.js in a webview to parse the jason template and data
+     *
+     * @param data_type
+     * @param data
+     * @param template
+     * @param context
+     */
     public void parse(final String data_type, final JSONObject data, final Object template, final Context context){
 
-        try{
-            new Thread(new Runnable(){
-                @Override public void run() {
+        String templateJson = template.toString();
+        String dataJson = data.toString();
 
-                    try {
-                        // thread handling - acquire handle
-                        juice.getLocker().acquire();
-                        Console console = new Console();
-                        V8Object v8Console = new V8Object(juice);
-                        juice.add("console", v8Console);
-                        v8Console.registerJavaMethod(console, "log", "log", new Class<?>[] { String.class });
-                        v8Console.registerJavaMethod(console, "error", "error", new Class<?>[] { String.class });
-                        v8Console.registerJavaMethod(console, "trace", "trace", new Class<?>[] {});
-
-                        V8Object parser = juice.getObject("parser");
-
-                        String templateJson = template.toString();
-                        String dataJson = data.toString();
-                        String val = "{}";
-
-                        if(data_type.equalsIgnoreCase("json")) {
-                            V8Array parameters = new V8Array(juice).push(templateJson);
-                            parameters.push(dataJson);
-                            parameters.push(true);
-                            val = parser.executeStringFunction("json", parameters);
-                            parameters.release();
-                        } else {
-                            String raw_data = data.getString("$jason");
-                            V8Array parameters = new V8Array(juice).push(templateJson);
-                            parameters.push(raw_data);
-                            parameters.push(true);
-                            val = parser.executeStringFunction("html", parameters);
-                            parameters.release();
-                        }
-                        parser.release();
-                        v8Console.release();
-
-
-                        res = new JSONObject(val);
-                        listener.onFinished(res);
-
-                    } catch (Exception e){
-                        Timber.w(e);
-                    }
-
-                    // thread handling - release handle
-                    juice.getLocker().release();
-               }
-            }).start();
-        } catch (Exception e){
-            Timber.w(e);
+        final String script;
+        if(data_type.equalsIgnoreCase(JSON_DATA_TYPE_VALUE)) {
+            script = String.format("%s(%s, %s, true);", PARSER_JSON_FUNCTION_NAME, templateJson, dataJson);
+        } else {
+            String raw_data = null;
+            try {
+                raw_data = data.getString(JasonModel.JASON_PROP_NAME);
+            } catch (JSONException e) {
+                Timber.e(e);
+            }
+            script = String.format("%s(%s, %s, true);",PARSER_HTML_FUNCTION_NAME, templateJson, raw_data);
         }
+        mHandler.post(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    mWebviewReadyLatch.await(WEBVIEW_READY_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    Timber.w(e);
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                    mWebView.evaluateJavascript(script, new ValueCallback<String>() {
+                        @Override
+                        public void onReceiveValue(String value) {
+                            try {
+                                if (value != null) {
+                                    // The string returned by the webview is a JSONObject or JSONArray or value
+                                    // in the case of parser.js we know it will only be a Object.
+                                    // BUT the string returned from a webview is also always wrapped in double quotes
+                                    // AND has double quotes escaped, eg. "{ \"foo]" : \"bar\"}"
+                                    // so we need the 2 replace calls to strip out both
+                                    // ref: https://stackoverflow.com/a/14884111/85472
+                                    //      https://stackoverflow.com/a/2608682/85472
+                                    value = value.replaceAll("^\"|\"$", "").replace("\\\"", "\"");
+                                }
+                                listener.onFinished((value != null && !"null".equals(value)) ? new JSONObject(value) : null);
+                            } catch (JSONException e) {
+                                Timber.e(e);
+                            }
+                        }
+                    });
+                } else {
+                    /**
+                     * For pre-KitKat+ you should use loadUrl("javascript:<JS Code Here>");
+                     * To then call back to Java you would need to use addJavascriptInterface()
+                     * and have your JS call the interface
+                     **/
+//                mWebView.loadUrl("javascript:"+javascript);
+                    throw new UnsupportedOperationException("Support for Pre-KitKat pending");
+                }
+            }
+        });
     }
 }
 
-
-/**
- * Override for console to print javascript debug output in the Android Studio console
- */
-class Console {
-    public void log(final String message) {
-        Timber.d(message);
-    }
-    public void error(final String message) {
-        Timber.e(message);
-    }
-    public void trace() {
-        Timber.e("Unable to reproduce JS stacktrace");
-    }
-}

--- a/app/src/main/java/com/jasonette/seed/Core/JasonRequire.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonRequire.java
@@ -21,6 +21,7 @@ import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
+import timber.log.Timber;
 
 public class JasonRequire implements Runnable{
     final String URL;
@@ -63,7 +64,7 @@ public class JasonRequire implements Runnable{
             Thread t = new Thread(r);
             t.start();
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
             latch.countDown();
         }
     }
@@ -140,13 +141,13 @@ public class JasonRequire implements Runnable{
                         }
                         latch.countDown();
                     } catch (JSONException e) {
-                        Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                        Timber.w(e);
                     }
                 }
             });
 
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 }

--- a/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Helper/JasonHelper.java
@@ -127,7 +127,7 @@ public class JasonHelper {
                 return new JSONObject();
             }
         } catch (Exception e) {
-            Timber.w(e, "error objectifying: %s", json);
+            Timber.w(e, "error objectifying");
             return new JSONObject();
         }
     }

--- a/app/src/main/java/com/jasonette/seed/Helper/JasonImageHelper.java
+++ b/app/src/main/java/com/jasonette/seed/Helper/JasonImageHelper.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Environment;
-import android.util.Log;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.model.GlideUrl;
@@ -18,9 +17,10 @@ import org.json.JSONObject;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.net.URI;
 import java.util.Iterator;
+
+import timber.log.Timber;
 
 public class JasonImageHelper {
     public interface JasonImageDownloadListener {
@@ -56,7 +56,7 @@ public class JasonImageHelper {
             Uri bitmapUri = Uri.fromFile(file);
             this.listener.onLoaded(this.data, bitmapUri);
         } catch (Exception e) {
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
 
     }
@@ -121,7 +121,7 @@ public class JasonImageHelper {
 
                                     listener.onLoaded(byteArray, bitmapUri);
                                 } catch (Exception e) {
-                                    Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                                    Timber.w(e);
                                 }
 
                             }
@@ -129,7 +129,7 @@ public class JasonImageHelper {
 
             }
         } catch (Exception e){
-            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            Timber.w(e);
         }
     }
 }

--- a/app/src/main/java/com/jasonette/seed/Section/ItemAdapter.java
+++ b/app/src/main/java/com/jasonette/seed/Section/ItemAdapter.java
@@ -3,7 +3,6 @@ package com.jasonette.seed.Section;
 import android.content.Context;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,6 +16,8 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
+import timber.log.Timber;
 
 
 /********************************************************
@@ -570,7 +571,7 @@ public class ItemAdapter extends RecyclerView.Adapter <ItemAdapter.ViewHolder>{
                 }
                 view.requestLayout();
             } catch (Exception e) {
-                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                Timber.w(e);
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">Jasonette</string>
-    <string name="url">http://10.0.2.2:8080/app.json</string>
+    <string name="url">https://jasonette.github.io/Jasonpedia/hello.json</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">Jasonette</string>
-    <string name="url">https://jasonette.github.io/Jasonpedia/hello.json</string>
+    <string name="url">http://10.0.2.2:8080/app.json</string>
 </resources>


### PR DESCRIPTION
This PR removes j2v8 as a dependency and instead uses Androids Webview to evaluate the JS scripts that Jasonette uses internally (`parser, csv, rss` js in the `assets` folder). 
New html assets have been added to enable the use of the webview for this purpose and a JS shim code added to support API levels below 19 where evaluateJS() is not available for webviews.

Also includes error logging refactor in a few other parts of the code.

Fixes: #162 