### PR TITLE
Centralise access to OkHttp client

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonNetworkAction.java
@@ -9,6 +9,7 @@ import android.util.Log;
 
 import com.jasonette.seed.Core.JasonViewActivity;
 import com.jasonette.seed.Helper.JasonHelper;
+import com.jasonette.seed.Launcher.DebugLauncher;
 import com.jasonette.seed.Launcher.Launcher;
 
 import org.json.JSONObject;
@@ -25,6 +26,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import timber.log.Timber;
 
 public class JasonNetworkAction {
     private void _request(final JSONObject callback, final JSONObject action, final JSONObject data, final JSONObject event, final Context context){
@@ -160,12 +162,12 @@ public class JasonNetworkAction {
                 }
 
 
-                OkHttpClient client = new OkHttpClient();
+                OkHttpClient client = ((Launcher)context.getApplicationContext()).getHttpClient();
 
                 client.newCall(request).enqueue(new Callback() {
                     @Override
                     public void onFailure(Call call, IOException e) {
-                        e.printStackTrace();
+                        Timber.e(e);
                         try {
                             if (action.has("error")) {
 

--- a/app/src/main/java/com/jasonette/seed/Action/JasonOauthAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonOauthAction.java
@@ -19,6 +19,7 @@ import com.github.scribejava.core.model.Verb;
 import com.github.scribejava.core.oauth.OAuth10aService;
 import com.github.scribejava.core.oauth.OAuth20Service;
 import com.jasonette.seed.Helper.JasonHelper;
+import com.jasonette.seed.Launcher.Launcher;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -557,7 +558,7 @@ public class JasonOauthAction {
                 } else {
                     uri_builder.appendQueryParameter("client_id", client_id);
                     uri_builder.appendQueryParameter("client_secret", client_secret);
-                    client = new OkHttpClient();
+                    client = ((Launcher)context.getApplicationContext()).getHttpClient();
                 }
 
                 Request request;


### PR DESCRIPTION
This ensures that all network requests go via same OkHttp client and eg. for debugging Stetho can intercept all requests.

Fixes: #168 