### PR TITLE
Offline should silently fail

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonModel.java
@@ -31,6 +31,7 @@ public class JasonModel{
     public JSONObject jason;
     public JSONObject rendered;
     public JSONObject state;
+    public boolean offline;
 
     public JSONObject refs;
 
@@ -49,6 +50,7 @@ public class JasonModel{
         this.url = url;
         this.view = view;
         this.client = ((Launcher)view.getApplication()).getHttpClient();
+        this.offline = false;
 
         // $params
         this.params = new JSONObject();
@@ -168,14 +170,14 @@ public class JasonModel{
             client.newCall(request).enqueue(new Callback() {
                 @Override
                 public void onFailure(Call call, IOException e) {
-                    fetch_local("file://error.json");
+                    if(!offline) fetch_local("file://error.json");
                     e.printStackTrace();
                 }
 
                 @Override
                 public void onResponse(Call call, final Response response) throws IOException {
                     if (!response.isSuccessful()) {
-                        fetch_local("file://error.json");
+                        if(!offline) fetch_local("file://error.json");
                     } else {
                         String res = response.body().string();
                         refs = new JSONObject();

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -248,41 +248,44 @@ public class JasonViewActivity extends AppCompatActivity {
                 Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
             }
         } else {
-
-            // offline: true logic
-            // 1. check if the url + params signature exists
-            // 2. if it does, use that to construct the model and setup_body
-            // 3. Go on to fetching (it will be re-rendered if fetch is successful)
-
-            // reset "offline mode"
-            model.offline = false;
-
-            SharedPreferences pref = getSharedPreferences("offline", 0);
-            String signature = model.url + model.params.toString();
-            if(pref.contains(signature)){
-                String offline = pref.getString(signature, null);
-                try {
-                    JSONObject offline_cache = new JSONObject(offline);
-                    model.jason = offline_cache.getJSONObject("jason");
-                    model.rendered = offline_cache.getJSONObject("rendered");
-                    model.offline = true;   // we confirm that this model is offline so it shouldn't trigger error.json when network fails
-                    setup_body(model.rendered);
-                } catch (Exception e) {
-                    Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
-                }
-            } else {
-                if(!model.url.startsWith("file://")) {
-                    // only load loading.json if loading from a remote JSON
-                    model.fetch_local("file://loading.json");
-                }
-            }
-
-            // Fetch
-            model.fetch();
+            onRefresh();
         }
 
     }
 
+    private void onRefresh() {
+        // offline: true logic
+        // 1. check if the url + params signature exists
+        // 2. if it does, use that to construct the model and setup_body
+        // 3. Go on to fetching (it will be re-rendered if fetch is successful)
+
+        // reset "offline mode"
+        model.offline = false;
+
+        SharedPreferences pref = getSharedPreferences("offline", 0);
+        String signature = model.url + model.params.toString();
+        if(pref.contains(signature)){
+            String offline = pref.getString(signature, null);
+            try {
+                JSONObject offline_cache = new JSONObject(offline);
+                model.jason = offline_cache.getJSONObject("jason");
+                model.rendered = offline_cache.getJSONObject("rendered");
+                model.offline = true;   // we confirm that this model is offline so it shouldn't trigger error.json when network fails
+                setup_body(model.rendered);
+            } catch (Exception e) {
+                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            }
+        } else {
+            if(!model.url.startsWith("file://")) {
+                // only load loading.json if loading from a remote JSON
+                model.fetch_local("file://loading.json");
+            }
+        }
+
+        // Fetch
+        model.fetch();
+
+    }
 
     
     @Override
@@ -1286,7 +1289,7 @@ public class JasonViewActivity extends AppCompatActivity {
                         intent.putExtra("params", params);
                     }
                     model = new JasonModel(url, intent, this);
-                    model.fetch();
+                    onRefresh();
                 } else {
                     Intent intent = new Intent(this, JasonViewActivity.class);
                     intent.putExtra("url", url);
@@ -1327,7 +1330,7 @@ public class JasonViewActivity extends AppCompatActivity {
 
     public void reload ( final JSONObject action, JSONObject data, JSONObject event, Context context){
         if(model != null){
-            model.fetch();
+            onRefresh();
             try {
                 JasonHelper.next("success", action, new JSONObject(), event, context);
             } catch (Exception e) {

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -254,6 +254,9 @@ public class JasonViewActivity extends AppCompatActivity {
             // 2. if it does, use that to construct the model and setup_body
             // 3. Go on to fetching (it will be re-rendered if fetch is successful)
 
+            // reset "offline mode"
+            model.offline = false;
+
             SharedPreferences pref = getSharedPreferences("offline", 0);
             String signature = model.url + model.params.toString();
             if(pref.contains(signature)){
@@ -262,6 +265,7 @@ public class JasonViewActivity extends AppCompatActivity {
                     JSONObject offline_cache = new JSONObject(offline);
                     model.jason = offline_cache.getJSONObject("jason");
                     model.rendered = offline_cache.getJSONObject("rendered");
+                    model.offline = true;   // we confirm that this model is offline so it shouldn't trigger error.json when network fails
                     setup_body(model.rendered);
                 } catch (Exception e) {
                     Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());


### PR DESCRIPTION
offline: true was not working when transitioning from one tab to another.

Turns out anything that uses `"transition": "replace"` suffered from this problem. Fixed this problem.