### PR TITLE
changes required for generating a signed apk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ android {
         versionCode 3
         versionName "0.1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -47,4 +48,5 @@ dependencies {
     compile 'com.github.florent37:singledateandtimepicker:1.0.8'
     compile 'com.jakewharton.timber:timber:4.5.1'
     compile 'com.google.android.gms:play-services:+'
+    compile 'com.android.support:multidex:1.0.0'
 }


### PR DESCRIPTION
changes required for generating a signed apk.

this was the minimum required to generate a signed apk with the latest tools.

there are [some indications](https://stackoverflow.com/questions/26609734/how-to-enable-multidexing-with-the-new-android-multidex-support-library/38473900#38473900) that a call may be needed early on in the main app code, but it does not seem to be required (step 2; step 3 seems to be covered in Jasonette-Android already).