### PR TITLE
Tab contents shouldn't reload every time, like how iOS works

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Launcher/Launcher.java
+++ b/app/src/main/java/com/jasonette/seed/Launcher/Launcher.java
@@ -11,6 +11,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 
 import com.bumptech.glide.request.target.ViewTarget;
+import com.jasonette.seed.Core.JasonModel;
 import com.jasonette.seed.Core.JasonViewActivity;
 import com.jasonette.seed.Helper.JasonHelper;
 import com.jasonette.seed.R;
@@ -36,6 +37,7 @@ public class Launcher extends Application {
     private JSONObject handlers;
     private JSONObject global;
     private JSONObject env;
+    private JSONObject models;
     private JSONObject services;
     private static Context currentContext;
 
@@ -57,6 +59,25 @@ public class Launcher extends Application {
         currentContext = context;
     }
 
+
+    public void setTabModel(String url, JasonModel model) {
+        try {
+            models.put(url, model);
+        } catch (Exception e) {
+
+        }
+    }
+    public JasonModel getTabModel(String url) {
+        try {
+            if (models.has(url)) {
+                return (JasonModel)models.get(url);
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
     public JSONObject getEnv(){
         return this.env;
@@ -150,6 +171,7 @@ public class Launcher extends Application {
             }
 
             this.env = new JSONObject();
+            this.models = new JSONObject();
 
             // device info
             JSONObject device = new JSONObject();


### PR DESCRIPTION
Currently the Android version handles tab switching differently than the iOS Jasonette.

On iOS, since the tab bar is natively built in and every tab co-exist without having to refresh every time you tap on a tab bar item.

But on Android tabs this has not been the case. On Android, if there are 5 tabs, all 5 tabs share the same activity since there is no native support for tab bar. Instead of having a parent tabs container that houses 5 views, on Android there's only one activity that gets "replace" transitioned out.

At least this was how it used to work. This meant whenever you press a tab bar item, it did a fresh reload of the view (since underneath it was just a replace transition).

In this update, we still keep the single activity structure, but instead of getting rid of all the rendered content, we store them globally. And when it's time to switch back to a previously-rendered tab, we look it up and restore its content seamlessly instead of reloading the URL from scratch.

This makes the tabs work the same way it works on iOS. 