### PR TITLE
Support $href action with a success callback

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Core/JasonCallback.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonCallback.java
@@ -1,0 +1,25 @@
+package com.jasonette.seed.Core;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.jasonette.seed.Helper.JasonHelper;
+
+import org.json.JSONObject;
+
+public class JasonCallback {
+    public void href(Intent intent, final JSONObject options) {
+        try {
+            JSONObject action = options.getJSONObject("action");
+            JSONObject event = options.getJSONObject("event");
+            Context context = (Context)options.get("context");
+
+            String return_string = intent.getStringExtra("return");
+            JSONObject return_value = new JSONObject(return_string);
+            JasonHelper.next("success", action, return_value, event, context);
+
+        } catch (Exception e) {
+
+        }
+    }
+}

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -1433,7 +1433,14 @@ public class JasonViewActivity extends AppCompatActivity {
                         intent.putExtra("preload", action.getJSONObject("options").getJSONObject("preload").toString());
                     }
                     intent.putExtra("depth", depth+1);
-                    startActivity(intent);
+
+                    // Start an Intent with a callback option:
+                    // 1. call dispatchIntent
+                    // 2. the intent will return with JasonCallback.href
+                    JSONObject callback = new JSONObject();
+                    callback.put("class", "JasonCallback");
+                    callback.put("method", "href");
+                    JasonHelper.dispatchIntent(action, data, event, context, intent, callback);
                 }
             }
 
@@ -1447,6 +1454,18 @@ public class JasonViewActivity extends AppCompatActivity {
     }
     public void close ( final JSONObject action, JSONObject data, JSONObject event, Context context){
        finish();
+    }
+    public void ok ( final JSONObject action, JSONObject data, JSONObject event, Context context){
+        try {
+            Intent intent = new Intent();
+            if (action.has("options")) {
+                intent.putExtra("return", action.get("options").toString());
+            }
+            setResult(RESULT_OK, intent);
+            finish();
+        } catch (Exception e) {
+            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+        }
     }
     public void unlock ( final JSONObject action, JSONObject data, JSONObject event, Context context){
         JasonViewActivity.this.runOnUiThread(new Runnable() {


### PR DESCRIPTION
## How it used to work

The `$href` action was one way street. You open a new view using the $href action but once you do so, there was no way to get a response back from the next view

```
{
  "type": "$href",
  "options": {
    "url": "..."
  }
}
```

## How it works now

Now the `$href` action supports `success` callback. 

```
{
  "type": "$href",
  "options": {
    "url": "..."
  },
  "success": {
    "type": "$util.alert",
    "options": {
      "title": "Return Value is",
      "description": "{{$jason.name}}"
    }
}
```

In order to return a value from an `$href` transition, you close the view using the `$ok` action.

The `$ok` is similar to `$back` in that it goes one step back regardless of whether it was opened modally or as a push transition (in case of iOS).

However the `$ok` can return a value to the parent view using its `options`. In order to make the previous example to work, the second view should return its control back to the first view using the following code:

```
{
  "type": "$ok",
  "options": {
    "name": "Alexa"
  }
}
```