### PR TITLE
textfield component keyboard type 'decimal' was using the standard number keyboard, and not allowing decimals

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Component/JasonTextareaComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonTextareaComponent.java
@@ -132,7 +132,7 @@ public class JasonTextareaComponent {
                     } else if(keyboard.equalsIgnoreCase("number")) {
                         ((EditText) view).setInputType(InputType.TYPE_CLASS_NUMBER);
                     } else if(keyboard.equalsIgnoreCase("decimal")) {
-                        ((EditText) view).setInputType(InputType.TYPE_CLASS_NUMBER);
+                        ((EditText) view).setInputType(InputType.TYPE_CLASS_NUMBER|InputType.TYPE_NUMBER_FLAG_DECIMAL);
                     } else if(keyboard.equalsIgnoreCase("phone")) {
                         ((EditText) view).setInputType(InputType.TYPE_CLASS_PHONE);
                     } else if(keyboard.equalsIgnoreCase("url")) {

--- a/app/src/main/java/com/jasonette/seed/Component/JasonTextfieldComponent.java
+++ b/app/src/main/java/com/jasonette/seed/Component/JasonTextfieldComponent.java
@@ -112,7 +112,7 @@ public class JasonTextfieldComponent {
                     } else if(keyboard.equalsIgnoreCase("number")) {
                         ((EditText) view).setInputType(InputType.TYPE_CLASS_NUMBER);
                     } else if(keyboard.equalsIgnoreCase("decimal")) {
-                        ((EditText) view).setInputType(InputType.TYPE_CLASS_NUMBER);
+                        ((EditText) view).setInputType(InputType.TYPE_CLASS_NUMBER|InputType.TYPE_NUMBER_FLAG_DECIMAL);
                     } else if(keyboard.equalsIgnoreCase("phone")) {
                         ((EditText) view).setInputType(InputType.TYPE_CLASS_PHONE);
                     } else if(keyboard.equalsIgnoreCase("url")) {


### PR DESCRIPTION
I just added the flag in Android for the decimal point.