### PR TITLE
Stringify

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Action/JasonUtilAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonUtilAction.java
@@ -49,7 +49,17 @@ public class JasonUtilAction {
             public void run() {
                 try {
                     JSONObject options = action.getJSONObject("options");
-                    Snackbar snackbar = Snackbar.make(((JasonViewActivity)context).rootLayout, options.getString("title") + "\n" + options.getString("description"), Snackbar.LENGTH_LONG);
+                    String title = "Notice";
+                    String result = "";
+                    if (options.has("title")) {
+                        title = options.get("title").toString();
+                    }
+                    if (options.has("description")) {
+                        result = title + "\n" + options.get("description").toString();
+                    } else {
+                        result = title;
+                    }
+                    Snackbar snackbar = Snackbar.make(((JasonViewActivity)context).rootLayout, result, Snackbar.LENGTH_LONG);
                     snackbar.show();
                 } catch (Exception e){
                     Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
@@ -69,7 +79,7 @@ public class JasonUtilAction {
                 try {
                     JSONObject options = action.getJSONObject("options");
                     int duration = Toast.LENGTH_SHORT;
-                    Toast toast = Toast.makeText(context, (CharSequence)options.getString("text"), duration);
+                    Toast toast = Toast.makeText(context, (CharSequence)options.get("text").toString(), duration);
                     toast.show();
                 } catch (Exception e){
                     Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
@@ -93,8 +103,8 @@ public class JasonUtilAction {
                     final ArrayList<EditText> textFields = new ArrayList<EditText>();
                     if (action.has("options")) {
                         options = action.getJSONObject("options");
-                        String title = options.getString("title");
-                        String description = options.getString("description");
+                        String title = options.get("title").toString();
+                        String description = options.get("description").toString();
                         builder.setTitle(title);
                         builder.setMessage(description);
 
@@ -181,7 +191,7 @@ public class JasonUtilAction {
                         final JSONArray items = options.getJSONArray("items");
                         AlertDialog.Builder builder = new AlertDialog.Builder(context);
                         if(options.has("title")){
-                            String title = options.getString("title");
+                            String title = options.get("title").toString();
                             builder.setTitle(title);
                         }
 
@@ -368,7 +378,7 @@ public class JasonUtilAction {
                             if (item.has("type")) {
                                 String type = item.getString("type");
                                 if (type.equalsIgnoreCase("text")) {
-                                    callback_intent.putExtra(Intent.EXTRA_TEXT, item.getString("text"));
+                                    callback_intent.putExtra(Intent.EXTRA_TEXT, item.get("text").toString());
                                     if (callback_intent.getType() == null) {
                                         callback_intent.setType("text/plain");
                                     }

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2417,6 +2417,12 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
                 }
 
             }
+            for (int i = 0; i < items.length(); i++) {
+                final JSONObject item = items.getJSONObject(i);
+                if (item.has("badge")) {
+                    bottomNavigation.setNotification(item.get("badge").toString(), i);
+                }
+            }
             bottomNavigation.setOnTabSelectedListener(new AHBottomNavigation.OnTabSelectedListener() {
                 @Override
                 public boolean onTabSelected(int position, boolean wasSelected) {
@@ -2673,7 +2679,7 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
                         String badge_text = "";
                         JSONObject badge = json.getJSONObject("badge");
                         if(badge.has("text")) {
-                            badge_text = badge.getString("text");
+                            badge_text = badge.get("text").toString();
                         }
                         JSONObject badge_style;
                         if (badge.has("style")) {

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2675,7 +2675,12 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
                         if(badge.has("text")) {
                             badge_text = badge.getString("text");
                         }
-                        JSONObject badge_style = badge.getJSONObject("style");
+                        JSONObject badge_style;
+                        if (badge.has("style")) {
+                            badge_style = badge.getJSONObject("style");
+                        } else {
+                            badge_style = new JSONObject();
+                        }
 
                         int color = JasonHelper.parse_color("#ffffff");
                         int background = JasonHelper.parse_color("#ff0000");
@@ -2690,8 +2695,8 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
 
                         FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT);
                         //layoutParams.gravity = Gravity.RIGHT | Gravity.TOP;
-                        int left = (int)JasonHelper.pixels(this, String.valueOf(20), "horizontal");
-                        int top = (int)JasonHelper.pixels(this, String.valueOf(-10), "vertical");
+                        int left = (int)JasonHelper.pixels(this, String.valueOf(30), "horizontal");
+                        int top = (int)JasonHelper.pixels(this, String.valueOf(-3), "vertical");
                         if(badge_style.has("left")){
                             left = (int)JasonHelper.pixels(this, badge_style.getString("left"), "horizontal");
                         }
@@ -2752,13 +2757,7 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
                 // set align:center by default
                 toolbar.setAlignment(Gravity.CENTER);
 
-                if (title instanceof String) {
-                    toolbar.setTitle(header.getString("title"));
-                    if(logoView != null){
-                        toolbar.removeView(logoView);
-                        logoView = null;
-                    }
-                } else if (title instanceof JSONObject) {
+                if (title instanceof JSONObject) {
                     JSONObject t = ((JSONObject) title);
                     String type = t.getString("type");
                     JSONObject style = null;
@@ -2854,6 +2853,13 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
                             toolbar.removeView(logoView);
                             logoView = null;
                         }
+                    }
+                } else {
+                    String simple_title = header.get("title").toString();
+                    toolbar.setTitle(simple_title);
+                    if(logoView != null){
+                        toolbar.removeView(logoView);
+                        logoView = null;
                     }
                 }
             } else {


### PR DESCRIPTION
Same as https://github.com/Jasonette/JASONETTE-iOS/pull/337 but for Android. Copy and pasting the comment:

---

Previously there was a strict rule about keeping every attribute a string format. This has confused a lot of people when getting started because for example you would expect something like this to work right out of the box:

```
{
  "type": "label", "text": 42
}
```

But it didn't because you had to EXPLICITLY set every attribute value to string, so the `42` had to be wrapped with double quotes like this:

```
{
  "type": "label", "text": "42"
}
```

This PR fixes this problem so all types automatically get typecasted to string when printing to the view. Numbers become strings and booleans become strings too (`true` becomes `"1"` and `false` becomes `"0"`)

Here are the features that have been updated to reflect this:

# View

- header
    - basic title
    - advanced title
    - menu
        - text
        - badge
            - text
- footer
    - tabs
        - items
            - text
            - badge
    - input
        - textfield
            - name
            - placeholder
        - right
            - text
- layers
    - type:label
        - text
    
- components
    - type:label
        - text
    - type:button
        - text
    - type:textfield
        - name
        - value
        - placeholder
    - type:textarea
        - name
        - value
        - placeholder
    - type:slider
        - name
        - value
    - type:switch
        - name
        - value
    - type:map
        - pins
            - title
            - description
    - type: Html
        - text


# Action

$util actions

# Styling

all styles with number metrics (size, width, height, etc.)