### PR TITLE
Add $sms.send action

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,6 +83,11 @@
         <uses-permission android:name="android.permission.WAKE_LOCK" />
     -->
 
+    <!-- Uncomment below line to enable $sms.send -->
+    <!--
+        <uses-permission android:name="android.permission.SEND_SMS"/>
+    -->
+
     <meta-data android:name="com.google.android.gms.vision.DEPENDENCIES" android:value="barcode"/>
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/app/src/main/java/com/jasonette/seed/Action/JasonSmsAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonSmsAction.java
@@ -1,0 +1,57 @@
+package com.jasonette.seed.Action;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
+import android.util.Log;
+import android.telephony.SmsManager;
+
+import com.jasonette.seed.Helper.JasonHelper;
+
+import org.json.JSONObject;
+
+
+public class JasonSmsAction {
+
+    public static int REQUEST_CODE = 9339;
+
+    /**
+     * {
+     *     "type": "$sms.send"
+     * }
+     */
+    public void send(final JSONObject action, final JSONObject data, final JSONObject event, final Context context) {
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    JSONObject options = action.getJSONObject("options");
+                    if (Build.VERSION.SDK_INT >= 23) {
+                        if(ContextCompat.checkSelfPermission(context, Manifest.permission.SEND_SMS) != PackageManager.PERMISSION_GRANTED){
+                            ActivityCompat.requestPermissions((Activity) context,new String[]{Manifest.permission.SEND_SMS}, 10);
+                        }
+                    }
+
+                    String number = options.get("number").toString();
+                    String text = options.get("text").toString();
+
+                    SmsManager sms = SmsManager.getDefault();
+                    sms.sendTextMessage(number, null, text, null, null);
+                } catch (Exception e){
+                    Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+                }
+            }
+        });
+        try {
+            JasonHelper.next("success", action, new JSONObject(), event, context);
+        } catch (Exception e) {
+            Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+        }
+    }
+}

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -49,6 +49,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
+import com.jasonette.seed.Action.JasonSmsAction;
 import com.jasonette.seed.Component.JasonComponentFactory;
 import com.jasonette.seed.Component.JasonImageComponent;
 import com.jasonette.seed.Helper.JasonHelper;
@@ -2935,6 +2936,9 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
     }
     @Override
     public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+        if (requestCode == JasonSmsAction.REQUEST_CODE ) {
+            return;
+        }
         if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
             cameraManager.startVision(JasonViewActivity.this);
         } else {


### PR DESCRIPTION
This pull request add the $sms.send action.
This action takes 2 options, the number and the text to send.
This action manages the request permission.

Jean-Sébastien