### PR TITLE
Add $util.getPermissions to action type

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Action/JasonUtilAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonUtilAction.java
@@ -184,7 +184,7 @@ public class JasonUtilAction {
 
 
                     }
-                    builder.setPositiveButton("OK",
+                    builder.setPositiveButton(android.R.string.ok,
                             new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog,
                                                     int which) {
@@ -205,7 +205,7 @@ public class JasonUtilAction {
                                     }
                                 }
                             });
-                    builder.setNeutralButton("CANCEL",
+                    builder.setNeutralButton(android.R.string.cancel,
                             new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog,
                                                     int which) {
@@ -265,7 +265,7 @@ public class JasonUtilAction {
                                 }
                             }
                         });
-                        builder.setNeutralButton("CANCEL",
+                        builder.setNeutralButton(android.R.string.cancel,
                             new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int val) {
                                 }

--- a/app/src/main/java/com/jasonette/seed/Action/JasonUtilAction.java
+++ b/app/src/main/java/com/jasonette/seed/Action/JasonUtilAction.java
@@ -1,19 +1,24 @@
 package com.jasonette.seed.Action;
 
+import android.Manifest;
 import android.app.Dialog;
 import android.app.TimePickerDialog;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.provider.ContactsContract;
 import android.support.design.widget.Snackbar;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.AlertDialog;
 import android.text.InputType;
@@ -35,6 +40,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -91,6 +97,38 @@ public class JasonUtilAction {
         } catch (Exception e) {
             Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
         }
+    }
+    public void getPermissions(final JSONObject action, final JSONObject data, final JSONObject event, final Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            int doPerm = 0;
+            String allPerm[] = new String[0];
+            try {
+                JSONObject options = action.getJSONObject("options");
+                if (options.has("permissions")) {
+                    String[] commaSeparatedArr = options.getString("permissions").split("\\s*,\\s*");
+                    ArrayList<String> listItems = new ArrayList<>(Arrays.asList(commaSeparatedArr));
+                    allPerm = new String[listItems.size()];
+                    for (int i = 0; i < listItems.size(); i++) {
+                        String newPer = new String("android.permission.") + listItems.get(i).toUpperCase();
+                        if (ContextCompat.checkSelfPermission(context, newPer) != PackageManager.PERMISSION_GRANTED) {
+                            allPerm[doPerm] = newPer;
+                            doPerm++;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
+            }
+            if (doPerm >= 1) {
+                JasonHelper.next("success", action, new JSONObject(), event, context);
+                ActivityCompat.requestPermissions((JasonViewActivity) context, allPerm, 0);
+            } else {
+                JasonHelper.next("error", action, new JSONObject(), event, context);
+            }
+        } else {
+            JasonHelper.next("error", action, new JSONObject(), event, context);
+        }
+
     }
     public void alert(final JSONObject action, final JSONObject data, final JSONObject event, final Context context){
         new Handler(Looper.getMainLooper()).post(new Runnable() {

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -16,6 +16,7 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Parcelable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.LocalBroadcastManager;
@@ -66,6 +67,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -1588,6 +1590,9 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
     public void flush ( final JSONObject action, JSONObject data, JSONObject event, Context context){
         // there's no default caching on Android. So don't do anything for now
         try {
+            for(File tempFile : context.getExternalFilesDir(Environment.DIRECTORY_PICTURES).listFiles()) {
+                tempFile.delete();
+            }
             JasonHelper.next("success", action, new JSONObject(), event, context);
         } catch (Exception e) {
             Log.d("Warning", e.getStackTrace()[0].getMethodName() + " : " + e.toString());
@@ -1912,7 +1917,7 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
 
                                     @Override
                                     public void onGlobalLayout() {
-                                        if(android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                                        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                                             rootLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                                         }
                                         else {
@@ -1947,7 +1952,7 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
                     rootLayout.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
                         @Override
                         public void onGlobalLayout() {
-                            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
                                 rootLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
                             } else {
                                 rootLayout.getViewTreeObserver().removeGlobalOnLayoutListener(this);

--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2936,7 +2936,7 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
     @Override
     public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
         if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            cameraManager.startVision(JasonViewActivity.this);
+            //cameraManager.startVision(JasonViewActivity.this);
         } else {
             Log.d("Warning", "Waiting for permission approval");
         }


### PR DESCRIPTION
Added new action for android-jasonette to get permissions on android 6+,
it returns "success" if android task of permissions is done, "error" if those permissions are already granted. As options you have to put permissions comma separated you need to granted, as example "permissions": "CAMERA,ACCESS_FINE_LOCATION".

Full code example:

"$load":{
          "type": "$util.getPermissions",
          "options": {
            "permissions": "CAMERA,ACCESS_FINE_LOCATION"
          },
          "error": {
            "trigger": "start"
          },
          "success": {
            "type": "$util.alert",
            "options": {
              "title": "Read before continue",
              "description": "Press \"OK\" to continue.\n- Press \"CANCEL\" to exit."
            },
            "success": {
              "type": "$flush",
              "success": {
                "type": "$reload"
              }
            },
            "error": {
              "type": "$close"
            }
          }
        }