### PR TITLE
Fix build.gradle for Android Studio v3.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
         google()
     }
     dependencies {


### PR DESCRIPTION
Following the quick start guide with Android Studio v3.2.1 yielded an error similar to what users have described here: https://stackoverflow.com/questions/52945041/couldnt-locate-lint-gradle-api-26-1-2-jar-for-flutter-project

Changing the order of jcenter() to load after maven seems to fix this issue.