### PR TITLE
Use website's default font size on background webview

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -1853,6 +1853,7 @@ public class JasonViewActivity extends AppCompatActivity implements ActivityComp
                                     JasonAgentService agentService = (JasonAgentService)((Launcher)getApplicationContext()).services.get("JasonAgentService");
                                     backgroundWebview = agentService.setup(JasonViewActivity.this, background, "$webcontainer@" + model.url);
                                     backgroundWebview.setVisibility(View.VISIBLE);
+                                    backgroundWebview.getSettings().setTextZoom(100);
                                     // not interactive by default;
                                     Boolean responds_to_webview = false;
 


### PR DESCRIPTION
When using a website URL on a background web container, the webview do not use the website font size.

```
"body": {
    "background": {
        "type": "html",
        "url": "https://www.notmywebsite.com"
     }
}
````

This PR fix this issue by **do not applying** any zoom on the text.